### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xRacket
+# Exercism Racket Track
 
 Exercism problems in Racket.
 
@@ -49,7 +49,7 @@ Prior to submitting a pull request, ensure that your test requires the stub file
 
   (run-tests suite))
 ```
-The exercise should also be added as a value for the `problems` key in [config.json](https://github.com/exercism/xracket/blob/master/config.json); otherwise, the pull request will not pass the Travis CI build. Use [Order of exercises](https://github.com/exercism/xracket/wiki/Order-of-exercises) in our wiki to find a good place for the new exercise in the curriculum.
+The exercise should also be added as a value for the `problems` key in [config.json](https://github.com/exercism/racket/blob/master/config.json); otherwise, the pull request will not pass the Travis CI build. Use [Order of exercises](https://github.com/exercism/racket/wiki/Order-of-exercises) in our wiki to find a good place for the new exercise in the curriculum.
 
 You can perform additional checks by running the following in your terminal:
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "racket",
   "language": "Racket",
-  "repository": "https://github.com/exercism/xracket",
+  "repository": "https://github.com/exercism/racket",
   "active": true,
   "exercises": [
     {


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1