### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_script:
 script:
   - "./bin/check-exercises.sh"
   - "./bin/fetch-configlet"
-  - "./bin/configlet ."
+  - "./bin/configlet lint ."
 after_script:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ bin/check_exercises.sh
 and:
 
 ```bash
-bin/configlet .
+bin/configlet lint .
 ```
 Your pull request won't pass the Travis CI build if either of those fail.
 


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23