### PR TITLE
config.json: Fix invalid exercise UUID

### DIFF
--- a/config.json
+++ b/config.json
@@ -104,7 +104,7 @@
         "strings"
       ],
       "unlocked_by": null,
-      "uuid": "d330a93f-063f-0d80-f35b-02cc2f9da754e0be296"
+      "uuid": "72ac5f36-ec1b-465e-b359-1cc49efc262d"
     },
     {
       "core": false,


### PR DESCRIPTION
The previous version of `configlet uuid` was known to generate invalid UUIDs. The latest release of Configlet [v3.6.1](https://github.com/exercism/configlet/releases) fixes that issue for newly added exercises, but existing exercise UUIDs need to be updated manually.

This change pertains to exercism/configlet#99