### PR TITLE
fix link to little schemer

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -5,4 +5,4 @@ These resources can help you get started:
 * [Continue: Web Applications in Racket](http://docs.racket-lang.org/continue/index.html)
 * [More: Systems Programming with Racket](http://docs.racket-lang.org/more/index.html)
 * [How to Design Programs](http://htdp.org/), by Matthias Felleisen, Robert Bruce Findler, Matthew Flatt, and Shiriam Krishnamurthi
-* [The Little Schemer](http://mitpress.mit.edu/books/little-schemer), by Daniel P. Friedman and Matthias Felleisen
+* [The Little Schemer](http://mitpress.mit.edu/books/little-schemer-fourth-edition), by Daniel P. Friedman and Matthias Felleisen


### PR DESCRIPTION
At the minute, this link ends up at a page saying "The requested page could not be found".

Looks like they've moved it to a fourth-edition specific page.