### PR TITLE
difference-of-squares: renamed square-of-sums to square-of-sum

### DIFF
--- a/exercises/difference-of-squares/difference-of-squares-test.rkt
+++ b/exercises/difference-of-squares/difference-of-squares-test.rkt
@@ -9,14 +9,14 @@
     (test-suite
      "difference of squares"
 
-     (test-eqv? "square-of-sums-to-5" (square-of-sums 5) 225)
+     (test-eqv? "square-of-sum-to-5" (square-of-sum 5) 225)
      (test-eqv? "sum-of-squares-to-5" (sum-of-squares 5) 55)
-     (test-eqv? "difference of-sums-to-5" (difference 5) 170)
-     (test-eqv? "square-of-sums-to-10" (square-of-sums 10) 3025)
+     (test-eqv? "difference-of-squares-to-5" (difference 5) 170)
+     (test-eqv? "square-of-sum-to-10" (square-of-sum 10) 3025)
      (test-eqv? "sum-of-squares-to-10"  (sum-of-squares 10) 385)
-     (test-eqv? "difference of-sums-to-10" (difference 10) 2640)
-     (test-eqv? "square-of-sums-to-100" (square-of-sums 100) 25502500)
+     (test-eqv? "difference-of-squares-to-10" (difference 10) 2640)
+     (test-eqv? "square-of-sum-to-100" (square-of-sum 100) 25502500)
      (test-eqv? "sum-of-squares-to-100" (sum-of-squares 100) 338350)
-     (test-eqv? "difference of-sums-to-100" (difference 100) 25164150)))
+     (test-eqv? "difference-of-squares-to-100" (difference 100) 25164150)))
 
   (run-tests suite))

--- a/exercises/difference-of-squares/difference-of-squares.rkt
+++ b/exercises/difference-of-squares/difference-of-squares.rkt
@@ -1,3 +1,3 @@
 #lang racket
 
-(provide sum-of-squares square-of-sums difference)
+(provide sum-of-squares square-of-sum difference)

--- a/exercises/difference-of-squares/example.rkt
+++ b/exercises/difference-of-squares/example.rkt
@@ -1,16 +1,16 @@
 #lang racket
 
-(provide sum-of-squares square-of-sums difference)
+(provide sum-of-squares square-of-sum difference)
 
 (define (sum-of-squares n)
   (for/sum
       ([i (in-range (add1 n))])
     (* i i)))
 
-(define (square-of-sums n)
+(define (square-of-sum n)
   (let ([sum (for/sum
                ([i (in-range (add1 n))]) i)])
     (* sum sum)))
 
 (define (difference n)
-  (- (square-of-sums n) (sum-of-squares n)))
+  (- (square-of-sum n) (sum-of-squares n)))


### PR DESCRIPTION
In exercise "difference-of-squares", renamed `square-of-sums` to `square-of-sum`, and `difference of-sums` to `difference-of-squares`.