### PR TITLE
update for perfect-numbers

### DIFF
--- a/exercises/perfect-numbers/.meta/hints.md
+++ b/exercises/perfect-numbers/.meta/hints.md
@@ -1,0 +1,5 @@
+## Implementation
+
+Implement a procedure named `classify` that takes a number as argument and return either `'perfect`,
+`'abundant`, or `'deficient`.
+

--- a/exercises/perfect-numbers/.meta/hints.md
+++ b/exercises/perfect-numbers/.meta/hints.md
@@ -1,5 +1,5 @@
 ## Implementation
 
-Implement a procedure named `classify` that takes a number as argument and return either `'perfect`,
+Implement a procedure named `classify` that takes a number as argument and returns either `'perfect`,
 `'abundant`, or `'deficient`.
 

--- a/exercises/perfect-numbers/example.rkt
+++ b/exercises/perfect-numbers/example.rkt
@@ -1,10 +1,11 @@
 #lang racket
 
-(provide perfect-numbers)
+(require math/number-theory)
 
-(define (perfect-numbers n)
-  (filter perfect? (range 1 (add1 n))))
+(provide classify)
 
-(define (perfect? n)
-  (= (apply + (filter (lambda (x)
-            (zero? (modulo n x))) (range 1 n))) n))
+(define (classify n)
+  (let ([sumdivisors (- (divisor-sum n) n)])
+    (cond [(= n sumdivisors) 'perfect]
+          [(> n sumdivisors) 'deficient]
+          [else 'abundant])))

--- a/exercises/perfect-numbers/perfect-numbers-test.rkt
+++ b/exercises/perfect-numbers/perfect-numbers-test.rkt
@@ -9,20 +9,48 @@
     (test-suite
      "perfect numbers tests"
 
-     (test-equal? "no perfect numbers in 1 - 5"
-                  (perfect-numbers 5)
-                  '())
+     (test-equal? "Smallest perfect number"
+                  (classify 6)
+                  'perfect)
 
-     (test-equal? "return one perfect number for range 1 - 6"
-                  (perfect-numbers 6)
-                  '(6))
+     (test-equal? "Medium perfect number"
+                  (classify 28)
+                  'perfect)
 
-     (test-equal? "return 3 perfect numbers for range 1 - 1000"
-                  (perfect-numbers 1000)
-                  '(6 28 496))
+     (test-equal? "Large perfect number"
+                  (classify 33550336)
+                  'perfect)
 
-     (test-equal? "return 4 perfect numbers for range 1 - 10000"
-                  (perfect-numbers 10000)
-                  '(6 28 496 8128))))
+     (test-equal? "Smallest prime deficient number"
+                  (classify 2)
+                  'deficient)
+
+     (test-equal? "Smallest non-prime deficient number"
+                  (classify 4)
+                  'deficient)
+
+     (test-equal? "Medium deficient number"
+                  (classify 33550337)
+                  'deficient)
+
+     (test-equal? "Large deficient number"
+                  (classify 33550337)
+                  'deficient)
+
+     (test-equal? "Edge case (no factors other than itself)"
+                  (classify 1)
+                  'deficient)
+
+     (test-equal? "Smallest abundant number"
+                  (classify 12)
+                  'abundant)
+
+     (test-equal? "Medium abundant number"
+                  (classify 30)
+                  'abundant)
+
+     (test-equal? "Large abundant number"
+                  (classify 33550335)
+                  'abundant)))
 
   (run-tests suite))

--- a/exercises/perfect-numbers/perfect-numbers.rkt
+++ b/exercises/perfect-numbers/perfect-numbers.rkt
@@ -1,3 +1,4 @@
 #lang racket
 
-(provide perfect-numbers)
+(provide classify)
+


### PR DESCRIPTION
The perfect-numbers exercise for Racket seems to be outdated when compared to other programming languages. I took example on the [Go version](https://github.com/exercism/go/tree/master/exercises/perfect-numbers). 

Note that contrary to the Go Version, this one doesn't ask for an error/exception to be throw if the passed argument is negative or zero.