### PR TITLE
tests in line with problem specification

### DIFF
--- a/exercises/leap/leap-test.rkt
+++ b/exercises/leap/leap-test.rkt
@@ -10,9 +10,11 @@
      "leap tests"
 
      (test-eqv? "vanilla-leap-year" (leap-year? 1996) #t)
-     (test-eqv? "any-old-year" (leap-year? 1997)#f)
+     (test-eqv? "any-old-year" (leap-year? 2015)#f)
      (test-eqv? "non-leap-even-year" (leap-year? 1998) #f)
-     (test-eqv? "century" (leap-year? 1900)#f)
-     (test-eqv? "exceptional-century" (leap-year? 2400) #t)))
+     (test-eqv? "century" (leap-year? 2100)#f)
+     (test-eqv? "not an exceptional-century" (leap-year? 1800) #f)
+     (test-eqv? "exceptional-century" (leap-year? 2000) #t))
+    ))
 
   (run-tests suite))

--- a/exercises/leap/leap-test.rkt
+++ b/exercises/leap/leap-test.rkt
@@ -14,7 +14,6 @@
      (test-eqv? "non-leap-even-year" (leap-year? 1998) #f)
      (test-eqv? "century" (leap-year? 2100)#f)
      (test-eqv? "not an exceptional-century" (leap-year? 1800) #f)
-     (test-eqv? "exceptional-century" (leap-year? 2000) #t))
-    ))
+     (test-eqv? "exceptional-century" (leap-year? 2000) #t)))
 
   (run-tests suite))


### PR DESCRIPTION
I noticed it was possible to have a solution which allowed years like 1800 to sneak through the current suite.  On reading https://github.com/exercism/problem-specifications/blob/master/exercises/leap/canonical-data.json (see also https://github.com/exercism/problem-specifications/commit/3134d31aeebf74374b7aaa11b6f35a8f80fa7b46) I realised our test data had drifted.