### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64d97c14-36dd-44a8-9621-2cecebd6ed23]
+description = "accumulate empty"
+
+[00008ed2-4651-4929-8c08-8b4dbd70872e]
+description = "accumulate squares"
+
+[551016da-4396-4cae-b0ec-4c3a1a264125]
+description = "accumulate upcases"
+
+[cdf95597-b6ec-4eac-a838-3480d13d0d05]
+description = "accumulate reversed strings"
+
+[bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
+description = "accumulate recursively"

--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
+
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
+
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
+
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
+
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
+
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/affine-cipher/.meta/tests.toml
+++ b/exercises/practice/affine-cipher/.meta/tests.toml
@@ -1,0 +1,58 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a]
+description = "encode -> encode yes"
+
+[785bade9-e98b-4d4f-a5b0-087ba3d7de4b]
+description = "encode -> encode no"
+
+[2854851c-48fb-40d8-9bf6-8f192ed25054]
+description = "encode -> encode OMG"
+
+[bc0c1244-b544-49dd-9777-13a770be1bad]
+description = "encode -> encode O M G"
+
+[381a1a20-b74a-46ce-9277-3778625c9e27]
+description = "encode -> encode mindblowingly"
+
+[6686f4e2-753b-47d4-9715-876fdc59029d]
+description = "encode -> encode numbers"
+
+[ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3]
+description = "encode -> encode deep thought"
+
+[c93a8a4d-426c-42ef-9610-76ded6f7ef57]
+description = "encode -> encode all the letters"
+
+[0673638a-4375-40bd-871c-fb6a2c28effb]
+description = "encode -> encode with a not coprime to m"
+
+[3f0ac7e2-ec0e-4a79-949e-95e414953438]
+description = "decode -> decode exercism"
+
+[241ee64d-5a47-4092-a5d7-7939d259e077]
+description = "decode -> decode a sentence"
+
+[33fb16a1-765a-496f-907f-12e644837f5e]
+description = "decode -> decode numbers"
+
+[20bc9dce-c5ec-4db6-a3f1-845c776bcbf7]
+description = "decode -> decode all the letters"
+
+[623e78c0-922d-49c5-8702-227a3e8eaf81]
+description = "decode -> decode with no spaces in input"
+
+[58fd5c2a-1fd9-4563-a80a-71cff200f26f]
+description = "decode -> decode with too many spaces"
+
+[b004626f-c186-4af9-a3f4-58f74cdb86d5]
+description = "decode -> decode with a not coprime to m"

--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -1,0 +1,73 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
+description = "single bit one to decimal"
+
+[0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
+description = "binary to single decimal"
+
+[f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
+description = "single decimal to binary"
+
+[2c45cf54-6da3-4748-9733-5a3c765d925b]
+description = "binary to multiple decimal"
+
+[65ddb8b4-8899-4fcc-8618-181b2cf0002d]
+description = "decimal to binary"
+
+[8d418419-02a7-4824-8b7a-352d33c6987e]
+description = "trinary to hexadecimal"
+
+[d3901c80-8190-41b9-bd86-38d988efa956]
+description = "hexadecimal to trinary"
+
+[5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
+description = "15-bit integer"
+
+[d68788f7-66dd-43f8-a543-f15b6d233f83]
+description = "empty list"
+
+[5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
+description = "single zero"
+
+[2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
+description = "multiple zeros"
+
+[3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
+description = "leading zeros"
+
+[a6b476a1-1901-4f2a-92c4-4d91917ae023]
+description = "input base is one"
+
+[e21a693a-7a69-450b-b393-27415c26a016]
+description = "input base is zero"
+
+[54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
+description = "input base is negative"
+
+[9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
+description = "negative digit"
+
+[232fa4a5-e761-4939-ba0c-ed046cd0676a]
+description = "invalid positive digit"
+
+[14238f95-45da-41dc-95ce-18f860b30ad3]
+description = "output base is one"
+
+[73dac367-da5c-4a37-95fe-c87fad0a4047]
+description = "output base is zero"
+
+[13f81f42-ff53-4e24-89d9-37603a48ebd9]
+description = "output base is negative"
+
+[0e6c895d-8a5d-4868-a345-309d094cfe8d]
+description = "both bases are negative"

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,0 +1,157 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "testing for eggs allergy -> not allergic to anything"
+
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "testing for eggs allergy -> allergic only to eggs"
+
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "testing for eggs allergy -> allergic to eggs and something else"
+
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "testing for eggs allergy -> allergic to something, but not eggs"
+
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "testing for eggs allergy -> allergic to everything"
+
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "testing for peanuts allergy -> not allergic to anything"
+
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "testing for peanuts allergy -> allergic only to peanuts"
+
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
+
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
+
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "testing for peanuts allergy -> allergic to everything"
+
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "testing for shellfish allergy -> not allergic to anything"
+
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "testing for shellfish allergy -> allergic only to shellfish"
+
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
+
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
+
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "testing for shellfish allergy -> allergic to everything"
+
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "testing for strawberries allergy -> not allergic to anything"
+
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "testing for strawberries allergy -> allergic only to strawberries"
+
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
+
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
+
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "testing for strawberries allergy -> allergic to everything"
+
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "testing for tomatoes allergy -> not allergic to anything"
+
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
+
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
+
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
+
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "testing for tomatoes allergy -> allergic to everything"
+
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "testing for chocolate allergy -> not allergic to anything"
+
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "testing for chocolate allergy -> allergic only to chocolate"
+
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
+
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
+
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "testing for chocolate allergy -> allergic to everything"
+
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "testing for pollen allergy -> not allergic to anything"
+
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "testing for pollen allergy -> allergic only to pollen"
+
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "testing for pollen allergy -> allergic to pollen and something else"
+
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "testing for pollen allergy -> allergic to something, but not pollen"
+
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "testing for pollen allergy -> allergic to everything"
+
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "testing for cats allergy -> not allergic to anything"
+
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "testing for cats allergy -> allergic only to cats"
+
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "testing for cats allergy -> allergic to cats and something else"
+
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "testing for cats allergy -> allergic to something, but not cats"
+
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "testing for cats allergy -> allergic to everything"
+
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "list when: -> no allergies"
+
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "list when: -> just eggs"
+
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "list when: -> just peanuts"
+
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "list when: -> just strawberries"
+
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "list when: -> eggs and peanuts"
+
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "list when: -> more than eggs but not peanuts"
+
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "list when: -> lots of stuff"
+
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "list when: -> everything"
+
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "list when: -> no allergen score parts"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,0 +1,56 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single digit numbers are Armstrong numbers"
+
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no 2 digit Armstrong numbers"
+
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three digit number that is an Armstrong number"
+
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three digit number that is not an Armstrong number"
+
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four digit number that is an Armstrong number"
+
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four digit number that is not an Armstrong number"
+
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven digit number that is an Armstrong number"
+
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven digit number that is not an Armstrong number"

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode -> encode yes"
+
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode -> encode no"
+
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode -> encode OMG"
+
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode -> encode spaces"
+
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode -> encode mindblowingly"
+
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode -> encode numbers"
+
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode -> encode deep thought"
+
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode -> encode all the letters"
+
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode -> decode exercism"
+
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode -> decode a sentence"
+
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode -> decode numbers"
+
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode -> decode all the letters"
+
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode -> decode with too many spaces"
+
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode -> decode with no spaces"

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,0 +1,85 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,0 +1,22 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
+
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
+
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
+
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"

--- a/exercises/practice/grep/.meta/tests.toml
+++ b/exercises/practice/grep/.meta/tests.toml
@@ -1,0 +1,85 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9049fdfd-53a7-4480-a390-375203837d09]
+description = "Test grepping a single file -> One file, one match, no flags"
+
+[76519cce-98e3-46cd-b287-aac31b1d77d6]
+description = "Test grepping a single file -> One file, one match, print line numbers flag"
+
+[af0b6d3c-e0e8-475e-a112-c0fc10a1eb30]
+description = "Test grepping a single file -> One file, one match, case-insensitive flag"
+
+[ff7af839-d1b8-4856-a53e-99283579b672]
+description = "Test grepping a single file -> One file, one match, print file names flag"
+
+[8625238a-720c-4a16-81f2-924ec8e222cb]
+description = "Test grepping a single file -> One file, one match, match entire lines flag"
+
+[2a6266b3-a60f-475c-a5f5-f5008a717d3e]
+description = "Test grepping a single file -> One file, one match, multiple flags"
+
+[842222da-32e8-4646-89df-0d38220f77a1]
+description = "Test grepping a single file -> One file, several matches, no flags"
+
+[4d84f45f-a1d8-4c2e-a00e-0b292233828c]
+description = "Test grepping a single file -> One file, several matches, print line numbers flag"
+
+[0a483b66-315b-45f5-bc85-3ce353a22539]
+description = "Test grepping a single file -> One file, several matches, match entire lines flag"
+
+[3d2ca86a-edd7-494c-8938-8eeed1c61cfa]
+description = "Test grepping a single file -> One file, several matches, case-insensitive flag"
+
+[1f52001f-f224-4521-9456-11120cad4432]
+description = "Test grepping a single file -> One file, several matches, inverted flag"
+
+[7a6ede7f-7dd5-4364-8bf8-0697c53a09fe]
+description = "Test grepping a single file -> One file, no matches, various flags"
+
+[3d3dfc23-8f2a-4e34-abd6-7b7d140291dc]
+description = "Test grepping a single file -> One file, one match, file flag takes precedence over line flag"
+
+[87b21b24-b788-4d6e-a68b-7afe9ca141fe]
+description = "Test grepping a single file -> One file, several matches, inverted and match entire lines flags"
+
+[ba496a23-6149-41c6-a027-28064ed533e5]
+description = "Test grepping multiples files at once -> Multiple files, one match, no flags"
+
+[4539bd36-6daa-4bc3-8e45-051f69f5aa95]
+description = "Test grepping multiples files at once -> Multiple files, several matches, no flags"
+
+[9fb4cc67-78e2-4761-8e6b-a4b57aba1938]
+description = "Test grepping multiples files at once -> Multiple files, several matches, print line numbers flag"
+
+[aeee1ef3-93c7-4cd5-af10-876f8c9ccc73]
+description = "Test grepping multiples files at once -> Multiple files, one match, print file names flag"
+
+[d69f3606-7d15-4ddf-89ae-01df198e6b6c]
+description = "Test grepping multiples files at once -> Multiple files, several matches, case-insensitive flag"
+
+[82ef739d-6701-4086-b911-007d1a3deb21]
+description = "Test grepping multiples files at once -> Multiple files, several matches, inverted flag"
+
+[77b2eb07-2921-4ea0-8971-7636b44f5d29]
+description = "Test grepping multiples files at once -> Multiple files, one match, match entire lines flag"
+
+[e53a2842-55bb-4078-9bb5-04ac38929989]
+description = "Test grepping multiples files at once -> Multiple files, one match, multiple flags"
+
+[9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb]
+description = "Test grepping multiples files at once -> Multiple files, no matches, various flags"
+
+[ba5a540d-bffd-481b-bd0c-d9a30f225e01]
+description = "Test grepping multiples files at once -> Multiple files, several matches, file flag takes precedence over line number flag"
+
+[ff406330-2f0b-4b17-9ee4-4b71c31dd6d2]
+description = "Test grepping multiples files at once -> Multiple files, several matches, inverted and match entire lines flags"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+
+[0d0b8644-0a1e-4a31-a432-2b3ee270d847]
+description = "word with duplicated character and with two hyphens"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,0 +1,100 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b9452-bf94-40f7-a3db-c3cf4850066a]
+description = "append entries to a list and return the new list -> empty lists"
+
+[2c894696-b609-4569-b149-8672134d340a]
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
+
+[71dcf5eb-73ae-4a0e-b744-a52ee387922f]
+description = "append entries to a list and return the new list -> non-empty lists"
+
+[28444355-201b-4af2-a2f6-5550227bde21]
+description = "concatenate a list of lists -> empty list"
+
+[331451c1-9573-42a1-9869-2d06e3b389a9]
+description = "concatenate a list of lists -> list of lists"
+
+[d6ecd72c-197f-40c3-89a4-aa1f45827e09]
+description = "concatenate a list of lists -> list of nested lists"
+
+[0524fba8-3e0f-4531-ad2b-f7a43da86a16]
+description = "filter list returning only values that satisfy the filter function -> empty list"
+
+[88494bd5-f520-4edb-8631-88e415b62d24]
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
+
+[1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
+description = "returns the length of a list -> empty list"
+
+[d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
+description = "returns the length of a list -> non-empty list"
+
+[c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
+
+[11e71a95-e78b-4909-b8e4-60cdcaec0e91]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
+
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+
+[36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
+
+[7a626a3c-03ec-42bc-9840-53f280e13067]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
+
+[d7fcad99-e88e-40e1-a539-4c519681f390]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
+
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+
+[17214edb-20ba-42fc-bda8-000a5ab525b0]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
+
+[e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
+
+[8066003b-f2ff-437e-9103-66e6df474844]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
+
+[94231515-050e-4841-943d-d4488ab4ee30]
+description = "reverse the elements of the list -> empty list"
+
+[fcc03d1e-42e0-4712-b689-d54ad761f360]
+description = "reverse the elements of the list -> non-empty list"
+
+[40872990-b5b8-4cb8-9085-d91fc0d05d26]
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -1,0 +1,295 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
+description = "monteenth of May 2013"
+
+[f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
+description = "monteenth of August 2013"
+
+[8c78bea7-a116-425b-9c6b-c9898266d92a]
+description = "monteenth of September 2013"
+
+[cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
+description = "tuesteenth of March 2013"
+
+[69048961-3b00-41f9-97ee-eb6d83a8e92b]
+description = "tuesteenth of April 2013"
+
+[d30bade8-3622-466a-b7be-587414e0caa6]
+description = "tuesteenth of August 2013"
+
+[8db4b58b-92f3-4687-867b-82ee1a04f851]
+description = "wednesteenth of January 2013"
+
+[6c27a2a2-28f8-487f-ae81-35d08c4664f7]
+description = "wednesteenth of February 2013"
+
+[008a8674-1958-45b5-b8e6-c2c9960d973a]
+description = "wednesteenth of June 2013"
+
+[e4abd5e3-57cb-4091-8420-d97e955c0dbd]
+description = "thursteenth of May 2013"
+
+[85da0b0f-eace-4297-a6dd-63588d5055b4]
+description = "thursteenth of June 2013"
+
+[ecf64f9b-8413-489b-bf6e-128045f70bcc]
+description = "thursteenth of September 2013"
+
+[ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
+description = "friteenth of April 2013"
+
+[b79101c7-83ad-4f8f-8ec8-591683296315]
+description = "friteenth of August 2013"
+
+[6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
+description = "friteenth of September 2013"
+
+[dfae03ed-9610-47de-a632-655ab01e1e7c]
+description = "saturteenth of February 2013"
+
+[ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
+description = "saturteenth of April 2013"
+
+[d983094b-7259-4195-b84e-5d09578c89d9]
+description = "saturteenth of October 2013"
+
+[d84a2a2e-f745-443a-9368-30051be60c2e]
+description = "sunteenth of May 2013"
+
+[0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
+description = "sunteenth of June 2013"
+
+[de87652c-185e-4854-b3ae-04cf6150eead]
+description = "sunteenth of October 2013"
+
+[2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
+description = "first Monday of March 2013"
+
+[a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
+description = "first Monday of April 2013"
+
+[1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
+description = "first Tuesday of May 2013"
+
+[12959c10-7362-4ca0-a048-50cf1c06e3e2]
+description = "first Tuesday of June 2013"
+
+[1033dc66-8d0b-48a1-90cb-270703d59d1d]
+description = "first Wednesday of July 2013"
+
+[b89185b9-2f32-46f4-a602-de20b09058f6]
+description = "first Wednesday of August 2013"
+
+[53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
+description = "first Thursday of September 2013"
+
+[b420a7e3-a94c-4226-870a-9eb3a92647f0]
+description = "first Thursday of October 2013"
+
+[61df3270-28b4-4713-bee2-566fa27302ca]
+description = "first Friday of November 2013"
+
+[cad33d4d-595c-412f-85cf-3874c6e07abf]
+description = "first Friday of December 2013"
+
+[a2869b52-5bba-44f0-a863-07bd1f67eadb]
+description = "first Saturday of January 2013"
+
+[3585315a-d0db-4ea1-822e-0f22e2a645f5]
+description = "first Saturday of February 2013"
+
+[c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
+description = "first Sunday of March 2013"
+
+[1513328b-df53-4714-8677-df68c4f9366c]
+description = "first Sunday of April 2013"
+
+[49e083af-47ec-4018-b807-62ef411efed7]
+description = "second Monday of March 2013"
+
+[6cb79a73-38fe-4475-9101-9eec36cf79e5]
+description = "second Monday of April 2013"
+
+[4c39b594-af7e-4445-aa03-bf4f8effd9a1]
+description = "second Tuesday of May 2013"
+
+[41b32c34-2e39-40e3-b790-93539aaeb6dd]
+description = "second Tuesday of June 2013"
+
+[90a160c5-b5d9-4831-927f-63a78b17843d]
+description = "second Wednesday of July 2013"
+
+[23b98ce7-8dd5-41a1-9310-ef27209741cb]
+description = "second Wednesday of August 2013"
+
+[447f1960-27ca-4729-bc3f-f36043f43ed0]
+description = "second Thursday of September 2013"
+
+[c9aa2687-300c-4e79-86ca-077849a81bde]
+description = "second Thursday of October 2013"
+
+[a7e11ef3-6625-4134-acda-3e7195421c09]
+description = "second Friday of November 2013"
+
+[8b420e5f-9290-4106-b5ae-022f3e2a3e41]
+description = "second Friday of December 2013"
+
+[80631afc-fc11-4546-8b5f-c12aaeb72b4f]
+description = "second Saturday of January 2013"
+
+[e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
+description = "second Saturday of February 2013"
+
+[a57d59fd-1023-47ad-b0df-a6feb21b44fc]
+description = "second Sunday of March 2013"
+
+[a829a8b0-abdd-4ad1-b66c-5560d843c91a]
+description = "second Sunday of April 2013"
+
+[501a8a77-6038-4fc0-b74c-33634906c29d]
+description = "third Monday of March 2013"
+
+[49e4516e-cf32-4a58-8bbc-494b7e851c92]
+description = "third Monday of April 2013"
+
+[4db61095-f7c7-493c-85f1-9996ad3012c7]
+description = "third Tuesday of May 2013"
+
+[714fc2e3-58d0-4b91-90fd-61eefd2892c0]
+description = "third Tuesday of June 2013"
+
+[b08a051a-2c80-445b-9b0e-524171a166d1]
+description = "third Wednesday of July 2013"
+
+[80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
+description = "third Wednesday of August 2013"
+
+[fa52a299-f77f-4784-b290-ba9189fbd9c9]
+description = "third Thursday of September 2013"
+
+[f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
+description = "third Thursday of October 2013"
+
+[8900f3b0-801a-466b-a866-f42d64667abd]
+description = "third Friday of November 2013"
+
+[538ac405-a091-4314-9ccd-920c4e38e85e]
+description = "third Friday of December 2013"
+
+[244db35c-2716-4fa0-88ce-afd58e5cf910]
+description = "third Saturday of January 2013"
+
+[dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
+description = "third Saturday of February 2013"
+
+[be71dcc6-00d2-4b53-a369-cbfae55b312f]
+description = "third Sunday of March 2013"
+
+[b7d2da84-4290-4ee6-a618-ee124ae78be7]
+description = "third Sunday of April 2013"
+
+[4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
+description = "fourth Monday of March 2013"
+
+[ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
+description = "fourth Monday of April 2013"
+
+[eb714ef4-1656-47cc-913c-844dba4ebddd]
+description = "fourth Tuesday of May 2013"
+
+[16648435-7937-4d2d-b118-c3e38fd084bd]
+description = "fourth Tuesday of June 2013"
+
+[de062bdc-9484-437a-a8c5-5253c6f6785a]
+description = "fourth Wednesday of July 2013"
+
+[c2ce6821-169c-4832-8d37-690ef5d9514a]
+description = "fourth Wednesday of August 2013"
+
+[d462c631-2894-4391-a8e3-dbb98b7a7303]
+description = "fourth Thursday of September 2013"
+
+[9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
+description = "fourth Thursday of October 2013"
+
+[83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
+description = "fourth Friday of November 2013"
+
+[de752d2a-a95e-48d2-835b-93363dac3710]
+description = "fourth Friday of December 2013"
+
+[eedd90ad-d581-45db-8312-4c6dcf9cf560]
+description = "fourth Saturday of January 2013"
+
+[669fedcd-912e-48c7-a0a1-228b34af91d0]
+description = "fourth Saturday of February 2013"
+
+[648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
+description = "fourth Sunday of March 2013"
+
+[f81321b3-99ab-4db6-9267-69c5da5a7823]
+description = "fourth Sunday of April 2013"
+
+[1af5e51f-5488-4548-aee8-11d7d4a730dc]
+description = "last Monday of March 2013"
+
+[f29999f2-235e-4ec7-9dab-26f137146526]
+description = "last Monday of April 2013"
+
+[31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
+description = "last Tuesday of May 2013"
+
+[8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
+description = "last Tuesday of June 2013"
+
+[0e762194-672a-4bdf-8a37-1e59fdacef12]
+description = "last Wednesday of July 2013"
+
+[5016386a-f24e-4bd7-b439-95358f491b66]
+description = "last Wednesday of August 2013"
+
+[12ead1a5-cdf9-4192-9a56-2229e93dd149]
+description = "last Thursday of September 2013"
+
+[7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
+description = "last Thursday of October 2013"
+
+[e47a739e-b979-460d-9c8a-75c35ca2290b]
+description = "last Friday of November 2013"
+
+[5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
+description = "last Friday of December 2013"
+
+[61e54cba-76f3-4772-a2b1-bf443fda2137]
+description = "last Saturday of January 2013"
+
+[8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
+description = "last Saturday of February 2013"
+
+[0b63e682-f429-4d19-9809-4a45bd0242dc]
+description = "last Sunday of March 2013"
+
+[5232307e-d3e3-4afc-8ba6-4084ad987c00]
+description = "last Sunday of April 2013"
+
+[0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
+description = "last Wednesday of February 2012"
+
+[fe0936de-7eee-4a48-88dd-66c07ab1fefc]
+description = "last Wednesday of December 2014"
+
+[2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
+description = "last Sunday of February 2015"
+
+[00c3ce9f-cf36-4b70-90d8-92b32be6830e]
+description = "first Friday of December 2012"

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"

--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[163e8e86-7bfd-4ee2-bd68-d083dc3381a3]
+description = "Perfect numbers -> Smallest perfect number is classified correctly"
+
+[169a7854-0431-4ae0-9815-c3b6d967436d]
+description = "Perfect numbers -> Medium perfect number is classified correctly"
+
+[ee3627c4-7b36-4245-ba7c-8727d585f402]
+description = "Perfect numbers -> Large perfect number is classified correctly"
+
+[80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
+description = "Abundant numbers -> Smallest abundant number is classified correctly"
+
+[3e300e0d-1a12-4f11-8c48-d1027165ab60]
+description = "Abundant numbers -> Medium abundant number is classified correctly"
+
+[ec7792e6-8786-449c-b005-ce6dd89a772b]
+description = "Abundant numbers -> Large abundant number is classified correctly"
+
+[e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
+description = "Deficient numbers -> Smallest prime deficient number is classified correctly"
+
+[0beb7f66-753a-443f-8075-ad7fbd9018f3]
+description = "Deficient numbers -> Smallest non-prime deficient number is classified correctly"
+
+[1c802e45-b4c6-4962-93d7-1cad245821ef]
+description = "Deficient numbers -> Medium deficient number is classified correctly"
+
+[47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
+description = "Deficient numbers -> Large deficient number is classified correctly"
+
+[a696dec8-6147-4d68-afad-d38de5476a56]
+description = "Deficient numbers -> Edge case (no factors other than itself) is classified correctly"
+
+[72445cee-660c-4d75-8506-6c40089dc302]
+description = "Invalid inputs -> Zero is rejected (as it is not a positive integer)"
+
+[2d72ce2c-6802-49ac-8ece-c790ba3dae13]
+description = "Invalid inputs -> Negative integer is rejected (as it is not a positive integer)"

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[79666dce-e0f1-46de-95a1-563802913c35]
+description = "cleans the number"
+
+[c360451f-549f-43e4-8aba-fdf6cb0bf83f]
+description = "cleans numbers with dots"
+
+[08f94c34-9a37-46a2-a123-2a8e9727395d]
+description = "cleans numbers with multiple spaces"
+
+[598d8432-0659-4019-a78b-1c6a73691d21]
+description = "invalid when 9 digits"
+
+[57061c72-07b5-431f-9766-d97da7c4399d]
+description = "invalid when 11 digits does not start with a 1"
+
+[9962cbf3-97bb-4118-ba9b-38ff49c64430]
+description = "valid when 11 digits and starting with 1"
+
+[fa724fbf-054c-4d91-95da-f65ab5b6dbca]
+description = "valid when 11 digits and starting with 1 even with punctuation"
+
+[c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
+description = "invalid when more than 11 digits"
+
+[63f38f37-53f6-4a5f-bd86-e9b404f10a60]
+description = "invalid with letters"
+
+[4bd97d90-52fd-45d3-b0db-06ab95b1244e]
+description = "invalid with punctuations"
+
+[d77d07f8-873c-4b17-8978-5f66139bf7d7]
+description = "invalid if area code starts with 0"
+
+[c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
+description = "invalid if area code starts with 1"
+
+[4d622293-6976-413d-b8bf-dd8a94d4e2ac]
+description = "invalid if exchange code starts with 0"
+
+[4cef57b4-7d8e-43aa-8328-1e1b89001262]
+description = "invalid if exchange code starts with 1"
+
+[9925b09c-1a0d-4960-a197-5d163cbe308c]
+description = "invalid if area code starts with 0 on valid 11-digit number"
+
+[3f809d37-40f3-44b5-ad90-535838b1a816]
+description = "invalid if area code starts with 1 on valid 11-digit number"
+
+[e08e5532-d621-40d4-b0cc-96c159276b65]
+description = "invalid if exchange code starts with 0 on valid 11-digit number"
+
+[57b32f3d-696a-455c-8bf1-137b6d171cdf]
+description = "invalid if exchange code starts with 1 on valid 11-digit number"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is I"
+
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is II"
+
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is III"
+
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4 is IV"
+
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is V"
+
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6 is VI"
+
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9 is IX"
+
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "27 is XXVII"
+
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is XLVIII"
+
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is XLIX"
+
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "59 is LIX"
+
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "93 is XCIII"
+
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "141 is CXLI"
+
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "163 is CLXIII"
+
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "402 is CDII"
+
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "575 is DLXXV"
+
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "911 is CMXI"
+
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1024 is MXXIV"
+
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -1,0 +1,55 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5d22a120-ba0c-428c-bd25-8682235d83e8]
+description = "zero"
+
+[9b5eed77-dbf6-439d-b920-3f7eb58928f6]
+description = "one"
+
+[7c499be1-612e-4096-a5e1-43b2f719406d]
+description = "fourteen"
+
+[f541dd8e-f070-4329-92b4-b7ce2fcf06b4]
+description = "twenty"
+
+[d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
+description = "twenty-two"
+
+[e417d452-129e-4056-bd5b-6eb1df334dce]
+description = "one hundred"
+
+[d6924f30-80ba-4597-acf6-ea3f16269da8]
+description = "one hundred twenty-three"
+
+[3d83da89-a372-46d3-b10d-de0c792432b3]
+description = "one thousand"
+
+[865af898-1d5b-495f-8ff0-2f06d3c73709]
+description = "one thousand two hundred thirty-four"
+
+[b6a3f442-266e-47a3-835d-7f8a35f6cf7f]
+description = "one million"
+
+[2cea9303-e77e-4212-b8ff-c39f1978fc70]
+description = "one million two thousand three hundred forty-five"
+
+[3e240eeb-f564-4b80-9421-db123f66a38f]
+description = "one billion"
+
+[9a43fed1-c875-4710-8286-5065d73b8a9e]
+description = "a big number"
+
+[49a6a17b-084e-423e-994d-a87c0ecc05ef]
+description = "numbers below zero are out of range"
+
+[4d6492eb-5853-4d16-9d34-b0f61b261fd9]
+description = "numbers above 999,999,999,999 are out of range"

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f46cda29-1ca5-4ef2-bd45-388a767e3db2]
+description = "lowercase letter"
+
+[f7794b49-f13e-45d1-a933-4e48459b2201]
+description = "uppercase letter"
+
+[eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
+description = "valuable letter"
+
+[f3c8c94e-bb48-4da2-b09f-e832e103151e]
+description = "short word"
+
+[71e3d8fa-900d-4548-930e-68e7067c4615]
+description = "short, valuable word"
+
+[d3088ad9-570c-4b51-8764-c75d5a430e99]
+description = "medium word"
+
+[fa20c572-ad86-400a-8511-64512daac352]
+description = "medium, valuable word"
+
+[9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
+description = "long, mixed-case word"
+
+[1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
+description = "english-like word"
+
+[4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
+description = "empty input"
+
+[3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
+description = "entire alphabet available"

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,0 +1,19 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"

--- a/exercises/practice/variable-length-quantity/.meta/tests.toml
+++ b/exercises/practice/variable-length-quantity/.meta/tests.toml
@@ -1,0 +1,88 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[35c9db2e-f781-4c52-b73b-8e76427defd0]
+description = "Encode a series of integers, producing a series of bytes. -> zero"
+
+[be44d299-a151-4604-a10e-d4b867f41540]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary single byte"
+
+[ea399615-d274-4af6-bbef-a1c23c9e1346]
+description = "Encode a series of integers, producing a series of bytes. -> largest single byte"
+
+[77b07086-bd3f-4882-8476-8dcafee79b1c]
+description = "Encode a series of integers, producing a series of bytes. -> smallest double byte"
+
+[63955a49-2690-4e22-a556-0040648d6b2d]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary double byte"
+
+[29da7031-0067-43d3-83a7-4f14b29ed97a]
+description = "Encode a series of integers, producing a series of bytes. -> largest double byte"
+
+[3345d2e3-79a9-4999-869e-d4856e3a8e01]
+description = "Encode a series of integers, producing a series of bytes. -> smallest triple byte"
+
+[5df0bc2d-2a57-4300-a653-a75ee4bd0bee]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary triple byte"
+
+[f51d8539-312d-4db1-945c-250222c6aa22]
+description = "Encode a series of integers, producing a series of bytes. -> largest triple byte"
+
+[da78228b-544f-47b7-8bfe-d16b35bbe570]
+description = "Encode a series of integers, producing a series of bytes. -> smallest quadruple byte"
+
+[11ed3469-a933-46f1-996f-2231e05d7bb6]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quadruple byte"
+
+[d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c]
+description = "Encode a series of integers, producing a series of bytes. -> largest quadruple byte"
+
+[91a18b33-24e7-4bfb-bbca-eca78ff4fc47]
+description = "Encode a series of integers, producing a series of bytes. -> smallest quintuple byte"
+
+[5f34ff12-2952-4669-95fe-2d11b693d331]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quintuple byte"
+
+[7489694b-88c3-4078-9864-6fe802411009]
+description = "Encode a series of integers, producing a series of bytes. -> maximum 32-bit integer input"
+
+[f9b91821-cada-4a73-9421-3c81d6ff3661]
+description = "Encode a series of integers, producing a series of bytes. -> two single-byte values"
+
+[68694449-25d2-4974-ba75-fa7bb36db212]
+description = "Encode a series of integers, producing a series of bytes. -> two multi-byte values"
+
+[51a06b5c-de1b-4487-9a50-9db1b8930d85]
+description = "Encode a series of integers, producing a series of bytes. -> many multi-byte values"
+
+[baa73993-4514-4915-bac0-f7f585e0e59a]
+description = "Decode a series of bytes, producing a series of integers. -> one byte"
+
+[72e94369-29f9-46f2-8c95-6c5b7a595aee]
+description = "Decode a series of bytes, producing a series of integers. -> two bytes"
+
+[df5a44c4-56f7-464e-a997-1db5f63ce691]
+description = "Decode a series of bytes, producing a series of integers. -> three bytes"
+
+[1bb58684-f2dc-450a-8406-1f3452aa1947]
+description = "Decode a series of bytes, producing a series of integers. -> four bytes"
+
+[cecd5233-49f1-4dd1-a41a-9840a40f09cd]
+description = "Decode a series of bytes, producing a series of integers. -> maximum 32-bit integer"
+
+[e7d74ba3-8b8e-4bcb-858d-d08302e15695]
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error"
+
+[aa378291-9043-4724-bc53-aca1b4a3fcb6]
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error, even if value is zero"
+
+[a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee]
+description = "Decode a series of bytes, producing a series of integers. -> multiple values"

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
+
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
+
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
+
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
+
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
+
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
+
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
+
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
+
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
+
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
+
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
+
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
+
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
