### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 "Racket (formerly named PLT Scheme) is a general purpose, multi-paradigm programming language in the Lisp/Scheme family. One of its design goals is to serve as a platform for language creation, design, and implementation. The language is used in a variety of contexts such as scripting, general-purpose programming, computer science education, and research." - [Wikipedia](https://en.wikipedia.org/wiki/Racket_(programming_language) "Wikipedia page on racket")
 
 You can learn the basics of Racket through a coule of books.  Start by checking out [How to Design Programs](https://htdp.org "How to Design Programs website") or the slightly less formal but enjoyable [Realm of Racket](http://www.realmofracket.com/ "Realm of Racket website").

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 Please reference Racket's [Getting Started](http://docs.racket-lang.org/getting-started/) page for instructions on downloading and installing Racket.
 
 Alternative installation options and further notes for specific OSes follow.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Racket for the first time.
 These resources can help you get started:
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * [The Racket Guide](http://docs.racket-lang.org/guide/index.html)
 * [The Racket Reference](http://docs.racket-lang.org/reference/index.html)
 * [DrRacket: The Racket Programming Environment](http://docs.racket-lang.org/drracket/index.html)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 You can run the provided tests through DrRacket, or via the command line.
 
 To run the test through DrRacket, simply open the test file and click the 'Run' button in the upper right.

--- a/exercises/practice/atbash-cipher/.docs/instructions.append.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.append.md
@@ -1,3 +1,3 @@
-## Note
+# Note
 
 The tests for this problem assume that numbers are passed through without being encrypted/decrypted.

--- a/exercises/practice/perfect-numbers/.docs/instructions.append.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Implement a procedure named `classify` that takes a number as argument and returns either `'perfect`,
 `'abundant`, or `'deficient`.

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,3 +1,3 @@
-## Note
+# Note
   
 For this problem, you will need to write the test.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
