### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "1e65bbe0-07fd-4fa5-9209-a0d176e6eba4",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Racket locally",
+      "blurb": "Learn how to install Racket locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "6116dc2e-62b0-409a-9316-b4f2a2529809",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Racket",
+      "blurb": "An overview of how to get started from scratch with Racket"
+    },
+    {
+      "uuid": "682f256f-0b36-4c8d-9d89-43df2856e14f",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Racket track",
+      "blurb": "Learn how to test your Racket exercises on Exercism"
+    },
+    {
+      "uuid": "c2155033-cb84-4495-9b3f-1327c851cd1d",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Racket resources",
+      "blurb": "A collection of useful resources to help you master Racket"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
