### PR TITLE
Fixes typo in ABOUT.md

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -2,7 +2,7 @@
 
 "Racket (formerly named PLT Scheme) is a general purpose, multi-paradigm programming language in the Lisp/Scheme family. One of its design goals is to serve as a platform for language creation, design, and implementation. The language is used in a variety of contexts such as scripting, general-purpose programming, computer science education, and research." - [Wikipedia](https://en.wikipedia.org/wiki/Racket_(programming_language) "Wikipedia page on racket")
 
-You can learn the basics of Racket through a coule of books.  Start by checking out [How to Design Programs](https://htdp.org "How to Design Programs website") or the slightly less formal but enjoyable [Realm of Racket](http://www.realmofracket.com/ "Realm of Racket website").
+You can learn the basics of Racket through a couple of books.  Start by checking out [How to Design Programs](https://htdp.org "How to Design Programs website") or the slightly less formal but enjoyable [Realm of Racket](http://www.realmofracket.com/ "Realm of Racket website").
 
 The official language website can be found at <http://racket-lang.org/> and the source code is at <https://github.com/racket/racket/>.  You can find the community on [twitter](https://twitter.com/racketlang), [email](https://lists.racket-lang.org/) or [slack](https://racket.slack.com/).
 


### PR DESCRIPTION
There is a small typo the ABOUT file for Racket: "coule" should instead by "couple" I assume.