### PR TITLE
adds or updates for stub implementations which throw an error (for exercises named 'a*')

### DIFF
--- a/exercises/practice/accumulate/accumulate.rkt
+++ b/exercises/practice/accumulate/accumulate.rkt
@@ -2,3 +2,5 @@
 
 (provide accumulate)
 
+(define (accumulate sequence operation)
+  (error "Not implemented yet"))

--- a/exercises/practice/acronym/acronym.rkt
+++ b/exercises/practice/acronym/acronym.rkt
@@ -1,3 +1,6 @@
 #lang racket
 
 (provide acronym)
+
+(define (acronym string)
+  (error "Not implemented yet"))

--- a/exercises/practice/affine-cipher/affine-cipher.rkt
+++ b/exercises/practice/affine-cipher/affine-cipher.rkt
@@ -10,7 +10,7 @@
                    exact-nonnegative-integer? . -> . string?)]))
 
 (define (encode msg a b)
-  "not implemented")
+  (error "Not implemented yet"))
 
 (define (decode msg a b)
-  "not implemented")
+  (error "Not implemented yet"))

--- a/exercises/practice/all-your-base/all-your-base.rkt
+++ b/exercises/practice/all-your-base/all-your-base.rkt
@@ -2,4 +2,5 @@
 
 (provide rebase)
 
-(define (rebase list-digits in-base out-base))
+(define (rebase list-digits in-base out-base)
+  (error "Not implemented yet"))

--- a/exercises/practice/allergies/allergies.rkt
+++ b/exercises/practice/allergies/allergies.rkt
@@ -2,6 +2,8 @@
 
 (provide list-allergies allergic-to?)
 
-(define (list-allergies score))
+(define (list-allergies score)
+  (error "Not implemented yet"))
 
-(define (allergic-to? str))
+(define (allergic-to? str score)
+  (error "Not implemented yet"))

--- a/exercises/practice/anagram/anagram.rkt
+++ b/exercises/practice/anagram/anagram.rkt
@@ -1,3 +1,6 @@
 #lang racket
 
 (provide anagrams-for)
+
+(define (anagrams-for string possibilities)
+  (error "Not implemented yet"))

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.rkt
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.rkt
@@ -3,4 +3,4 @@
 (provide armstrong-number?)
 
 (define (armstrong-number? n)
-  "not implemented")
+  (error "Not implemented yet"))

--- a/exercises/practice/atbash-cipher/atbash-cipher.rkt
+++ b/exercises/practice/atbash-cipher/atbash-cipher.rkt
@@ -1,7 +1,9 @@
 #lang racket
 
+(provide encode decode)
+
 (define (encode m)
-  (error "not implemented"))
+  (error "Not implemented yet"))
 
 (define (decode m)
-  (error "not implemented"))
+  (error "Not implemented yet"))


### PR DESCRIPTION
As mentioned in previous conversation: a stub for each exercise is nice to have as a user can immediately run `raco test .` and the tests will run (and fail) as the code is at least syntactically correct.

here ive updated any/all exercises whose name starts with `a` that needed updating