### PR TITLE
Update sublist-test.rkt

### DIFF
--- a/exercises/practice/sublist/sublist-test.rkt
+++ b/exercises/practice/sublist/sublist-test.rkt
@@ -5,10 +5,6 @@
 (module+ test
   (require rackunit rackunit/text-ui)
 
-  (define million (range 1000000))
-  (define million+1 (range 1 1000001))
-  (define million1s (make-list 1000000 1))
-
   (define suite
     (test-suite "sublist tests"
 
@@ -33,13 +29,6 @@
                 (test-eqv? "superlist at middle"      (sublist? '(1 2 3 4 5 6 7) '(3 4 5)) 'superlist)
                 (test-eqv? "superlist at end"         (sublist? '(1 2 3 4 5 6 7) '(5 6 7)) 'superlist)
 
-                ; large list
-                (test-eqv? "same big list"            (sublist? million million) 'equal)
-                (test-eqv? "different big lists"      (sublist? million million+1) 'unequal)
-                (test-eqv? "large found at start"     (sublist? (range 5000) million) 'sublist)
-                (test-eqv? "large found at middle"    (sublist? (range 650000 750000) million) 'sublist)
-                (test-eqv? "large found at end"       (sublist? million (range 995000 1000000)) 'superlist)
-
                 ; multiple matches
                 (test-eqv? "sublist w/ multiple matches"  (sublist? '(1 2 3) '(1 1 1 2 3)) 'sublist)
                 (test-eqv? "sublist w/ multiple matches"  (sublist? '(1 1 1 2 3) '(1 2 3)) 'superlist)
@@ -51,12 +40,6 @@
                 ; recurring values in sublist
                 (test-eqv? "recurring sublist"        (sublist? '(1 2 1 2 3) '(1 2 3 1 2 1 2 3 2 1)) 'sublist)
                 (test-eqv? "recurring unequal"        (sublist? '(1 2 1 2 3) '(1 2 3 1 2 3 2 3 2 1)) 'unequal)
-
-                ; slow tests
-                ; (test-case "slow: large at beginning"
-                ;            (check-eqv? (sublist? million1s (make-list 250000 1)) 'superlist))
-                ; (test-case "slow: large unequal"
-                ;            (check-eqv? (sublist? million1s (append (make-list 249999 1) '(2))) 'unequal))
 
                 ))
   (run-tests suite)


### PR DESCRIPTION
those huge, million or multiple thousand entry long lists grind racket to a halt and consume huge amounts of resources. This makes the tests impossible to run locally (unless we turn off those particular tests which require huge lists) and it also means the code fails on the server.