### PR TITLE
Sync tests for armstrong-numbers

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -13,25 +13,31 @@
 description = "Zero is an Armstrong number"
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
-description = "Single digit numbers are Armstrong numbers"
+description = "Single-digit numbers are Armstrong numbers"
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
-description = "There are no 2 digit Armstrong numbers"
+description = "There are no two-digit Armstrong numbers"
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
-description = "Three digit number that is an Armstrong number"
+description = "Three-digit number that is an Armstrong number"
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
-description = "Three digit number that is not an Armstrong number"
+description = "Three-digit number that is not an Armstrong number"
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
-description = "Four digit number that is an Armstrong number"
+description = "Four-digit number that is an Armstrong number"
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
-description = "Four digit number that is not an Armstrong number"
+description = "Four-digit number that is not an Armstrong number"
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
-description = "Seven digit number that is an Armstrong number"
+description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
-description = "Seven digit number that is not an Armstrong number"
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.rkt
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.rkt
@@ -1,27 +1,44 @@
 #lang racket/base
 
-; Tests adapted from canonical-data.json v1.1.0
 (require "armstrong-numbers.rkt")
 
 (module+ test
   (require rackunit rackunit/text-ui)
-  (run-tests
-   (test-suite "armstrong-numbers tests"
-               (test-true "Zero is an Armstrong number"
-                          (armstrong-number? 0))
-               (test-true "Single digit numbers are Armstrong numbers"
-                          (armstrong-number? 5))
-               (test-false "There are no 2 digit Armstrong numbers"
-                           (armstrong-number? 10))
-               (test-true "Three digit number that is an Armstrong number"
-                          (armstrong-number? 153))
-               (test-false "Three digit number that is not an Armstrong number"
-                           (armstrong-number? 100))
-               (test-true "Four digit number that is an Armstrong number"
-                          (armstrong-number? 9474))
-               (test-false "Four digit number that is not an Armstrong number"
-                           (armstrong-number? 9475))
-               (test-true "Seven digit number that is an Armstrong number"
-                          (armstrong-number? 9926315))
-               (test-false "Seven digit number that is not an Armstrong number"
-                          (armstrong-number? 9926314)))))
+
+  (define suite
+  	(test-suite
+  		"armstrong-numbers tests"
+  		(test-true "Zero is an Armstrong number"
+  					(armstrong-number? 0))
+
+        (test-true "Single-digit numbers are Armstrong numbers"
+  					(armstrong-number? 5))
+
+        (test-false "There are no two-digit Armstrong numbers"
+  					(armstrong-number? 10))
+
+        (test-true "Three-digit number that is an Armstrong number"
+  					(armstrong-number? 153))
+
+        (test-false "Three-digit number that is not an Armstrong number"
+  					(armstrong-number? 100))
+
+        (test-true "Four-digit number that is an Armstrong number"
+  					(armstrong-number? 9474))
+
+        (test-false "Four-digit number that is not an Armstrong number"
+  					(armstrong-number? 9475))
+
+        (test-true "Seven-digit number that is an Armstrong number"
+  					(armstrong-number? 9926315))
+
+        (test-false "Seven-digit number that is not an Armstrong number"
+  					(armstrong-number? 9926314))
+
+        (test-true "Armstrong number containing seven zeroes"
+  					(armstrong-number? 186709961001538790100634132976990))
+
+        (test-true "The largest and last Armstrong number"
+  					(armstrong-number? 115132219018763992565095597973971522401))))
+
+ (run-tests suite))

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.rkt
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.rkt
@@ -7,7 +7,7 @@
 
   (define suite
   	(test-suite
-  		"armstrong-numbers tests"
+  		"armstrong numbers tests"
   		(test-true "Zero is an Armstrong number"
   					(armstrong-number? 0))
 


### PR DESCRIPTION
Update test suite to reflect preferred setup in the README

May fix #274 