### PR TITLE
Run CI on Racket 8.8 - 8.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         racket-variant: ['BC', 'CS']
-        racket-version: ['8.8', '8.9']
+        racket-version: ['8.8', '8.9', '8.10']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Racket 8.10 came out in August, and versions come out every few months. Therefore, it'd make sense to test two versions back instead of one. `stable` is an option here instead of manually specifying the current release, but I don't see aliases for one and two releases back so it'd be confusing to maintain both aliases and explicit version numbers.