### PR TITLE
Add proverb exercise (#297)

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,18 +19,10 @@
     "average_run_time": 2
   },
   "files": {
-    "solution": [
-      "%{kebab_slug}.rkt"
-    ],
-    "test": [
-      "%{kebab_slug}-test.rkt"
-    ],
-    "example": [
-      ".meta/example.rkt"
-    ],
-    "exemplar": [
-      ".meta/exemplar.rkt"
-    ]
+    "solution": ["%{kebab_slug}.rkt"],
+    "test": ["%{kebab_slug}-test.rkt"],
+    "example": [".meta/example.rkt"],
+    "exemplar": [".meta/exemplar.rkt"]
   },
   "exercises": {
     "practice": [
@@ -38,9 +30,7 @@
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "4fb471fc-4e6d-486d-abf5-939e89f028fc",
-        "practices": [
-          "strings"
-        ],
+        "practices": ["strings"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -56,10 +46,7 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "27ffc2d2-e950-40a1-90fa-a1f3eec4fd36",
-        "practices": [
-          "optional-values",
-          "text-formatting"
-        ],
+        "practices": ["optional-values", "text-formatting"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -75,9 +62,7 @@
         "slug": "difference-of-squares",
         "name": "Difference of Squares",
         "uuid": "a3d9a2bb-a80a-487f-b529-64e20f7cf9b5",
-        "practices": [
-          "math"
-        ],
+        "practices": ["math"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -93,9 +78,7 @@
         "slug": "perfect-numbers",
         "name": "Perfect Numbers",
         "uuid": "72b2c36b-fcd5-4c8c-89e7-98bf24faaa3e",
-        "practices": [
-          "math"
-        ],
+        "practices": ["math"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -119,9 +102,7 @@
         "slug": "collatz-conjecture",
         "name": "Collatz Conjecture",
         "uuid": "28102e69-dad0-4f3c-8cdf-5a18a73178a4",
-        "practices": [
-          "math"
-        ],
+        "practices": ["math"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -145,11 +126,7 @@
         "slug": "twelve-days",
         "name": "Twelve Days",
         "uuid": "5961220f-5d33-4e97-a4bb-8b375714a8fc",
-        "practices": [
-          "enumerations",
-          "reduce",
-          "strings"
-        ],
+        "practices": ["enumerations", "reduce", "strings"],
         "prerequisites": [],
         "difficulty": 2
       },
@@ -157,12 +134,7 @@
         "slug": "isogram",
         "name": "Isogram",
         "uuid": "2fa21cb9-5469-4b95-9b78-c6f4dec6f67f",
-        "practices": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "strings"
-        ],
+        "practices": ["algorithms", "conditionals", "loops", "strings"],
         "prerequisites": [],
         "difficulty": 3
       },
@@ -185,11 +157,7 @@
         "slug": "armstrong-numbers",
         "name": "Armstrong Numbers",
         "uuid": "0fa9d2c6-f170-43b4-a28a-eb4994b4140e",
-        "practices": [
-          "algorithms",
-          "loops",
-          "math"
-        ],
+        "practices": ["algorithms", "loops", "math"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -197,11 +165,7 @@
         "slug": "affine-cipher",
         "name": "Affine Cipher",
         "uuid": "529c3ced-eefa-402c-b901-ea39ae2fb24e",
-        "practices": [
-          "algorithms",
-          "cryptography",
-          "strings"
-        ],
+        "practices": ["algorithms", "cryptography", "strings"],
         "prerequisites": [],
         "difficulty": 4
       },
@@ -226,12 +190,7 @@
         "slug": "all-your-base",
         "name": "All Your Base",
         "uuid": "f6617861-da32-4735-8c7f-5ae57a8cf44a",
-        "practices": [
-          "integers",
-          "map",
-          "math",
-          "transforming"
-        ],
+        "practices": ["integers", "map", "math", "transforming"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -341,9 +300,7 @@
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "135c7e52-04ac-4cde-9617-e16870dacb3f",
-        "practices": [
-          "strings"
-        ],
+        "practices": ["strings"],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -388,6 +345,14 @@
         "difficulty": 2
       },
       {
+        "slug": "proverb",
+        "name": "Proverb",
+        "uuid": "bcc730e2-40c0-485e-84f6-d8438371c7db",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "word-count",
         "name": "Word Count",
         "uuid": "b931f727-b5b1-4f42-9799-faca692dd32e",
@@ -399,11 +364,7 @@
         "slug": "atbash-cipher",
         "name": "Atbash Cipher",
         "uuid": "92d97f99-04f9-4a52-942d-d1a9fa96375f",
-        "practices": [
-          "algorithms",
-          "cryptography",
-          "strings"
-        ],
+        "practices": ["algorithms", "cryptography", "strings"],
         "prerequisites": [],
         "difficulty": 3
       },
@@ -411,10 +372,7 @@
         "slug": "variable-length-quantity",
         "name": "Variable Length Quantity",
         "uuid": "a6f90be2-1360-479e-8a6f-4f2d8b492c71",
-        "practices": [
-          "algorithms",
-          "bitwise-operations"
-        ],
+        "practices": ["algorithms", "bitwise-operations"],
         "prerequisites": [],
         "difficulty": 7
       },
@@ -455,11 +413,7 @@
         "slug": "house",
         "name": "House",
         "uuid": "79861b42-3bf8-4fe9-91f0-72b4c0a164f9",
-        "practices": [
-          "algorithms",
-          "recursion",
-          "strings"
-        ],
+        "practices": ["algorithms", "recursion", "strings"],
         "prerequisites": [],
         "difficulty": 4
       },

--- a/config.json
+++ b/config.json
@@ -19,10 +19,18 @@
     "average_run_time": 2
   },
   "files": {
-    "solution": ["%{kebab_slug}.rkt"],
-    "test": ["%{kebab_slug}-test.rkt"],
-    "example": [".meta/example.rkt"],
-    "exemplar": [".meta/exemplar.rkt"]
+    "solution": [
+      "%{kebab_slug}.rkt"
+    ],
+    "test": [
+      "%{kebab_slug}-test.rkt"
+    ],
+    "example": [
+      ".meta/example.rkt"
+    ],
+    "exemplar": [
+      ".meta/exemplar.rkt"
+    ]
   },
   "exercises": {
     "practice": [
@@ -30,7 +38,9 @@
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "4fb471fc-4e6d-486d-abf5-939e89f028fc",
-        "practices": ["strings"],
+        "practices": [
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -46,7 +56,10 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "27ffc2d2-e950-40a1-90fa-a1f3eec4fd36",
-        "practices": ["optional-values", "text-formatting"],
+        "practices": [
+          "optional-values",
+          "text-formatting"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -62,7 +75,9 @@
         "slug": "difference-of-squares",
         "name": "Difference of Squares",
         "uuid": "a3d9a2bb-a80a-487f-b529-64e20f7cf9b5",
-        "practices": ["math"],
+        "practices": [
+          "math"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -78,7 +93,9 @@
         "slug": "perfect-numbers",
         "name": "Perfect Numbers",
         "uuid": "72b2c36b-fcd5-4c8c-89e7-98bf24faaa3e",
-        "practices": ["math"],
+        "practices": [
+          "math"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -102,7 +119,9 @@
         "slug": "collatz-conjecture",
         "name": "Collatz Conjecture",
         "uuid": "28102e69-dad0-4f3c-8cdf-5a18a73178a4",
-        "practices": ["math"],
+        "practices": [
+          "math"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -126,7 +145,11 @@
         "slug": "twelve-days",
         "name": "Twelve Days",
         "uuid": "5961220f-5d33-4e97-a4bb-8b375714a8fc",
-        "practices": ["enumerations", "reduce", "strings"],
+        "practices": [
+          "enumerations",
+          "reduce",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 2
       },
@@ -134,7 +157,12 @@
         "slug": "isogram",
         "name": "Isogram",
         "uuid": "2fa21cb9-5469-4b95-9b78-c6f4dec6f67f",
-        "practices": ["algorithms", "conditionals", "loops", "strings"],
+        "practices": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 3
       },
@@ -157,7 +185,11 @@
         "slug": "armstrong-numbers",
         "name": "Armstrong Numbers",
         "uuid": "0fa9d2c6-f170-43b4-a28a-eb4994b4140e",
-        "practices": ["algorithms", "loops", "math"],
+        "practices": [
+          "algorithms",
+          "loops",
+          "math"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -165,7 +197,11 @@
         "slug": "affine-cipher",
         "name": "Affine Cipher",
         "uuid": "529c3ced-eefa-402c-b901-ea39ae2fb24e",
-        "practices": ["algorithms", "cryptography", "strings"],
+        "practices": [
+          "algorithms",
+          "cryptography",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 4
       },
@@ -190,7 +226,12 @@
         "slug": "all-your-base",
         "name": "All Your Base",
         "uuid": "f6617861-da32-4735-8c7f-5ae57a8cf44a",
-        "practices": ["integers", "map", "math", "transforming"],
+        "practices": [
+          "integers",
+          "map",
+          "math",
+          "transforming"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -300,7 +341,9 @@
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "135c7e52-04ac-4cde-9617-e16870dacb3f",
-        "practices": ["strings"],
+        "practices": [
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 1
       },
@@ -364,7 +407,11 @@
         "slug": "atbash-cipher",
         "name": "Atbash Cipher",
         "uuid": "92d97f99-04f9-4a52-942d-d1a9fa96375f",
-        "practices": ["algorithms", "cryptography", "strings"],
+        "practices": [
+          "algorithms",
+          "cryptography",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 3
       },
@@ -372,7 +419,10 @@
         "slug": "variable-length-quantity",
         "name": "Variable Length Quantity",
         "uuid": "a6f90be2-1360-479e-8a6f-4f2d8b492c71",
-        "practices": ["algorithms", "bitwise-operations"],
+        "practices": [
+          "algorithms",
+          "bitwise-operations"
+        ],
         "prerequisites": [],
         "difficulty": 7
       },
@@ -413,7 +463,11 @@
         "slug": "house",
         "name": "House",
         "uuid": "79861b42-3bf8-4fe9-91f0-72b4c0a164f9",
-        "practices": ["algorithms", "recursion", "strings"],
+        "practices": [
+          "algorithms",
+          "recursion",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 4
       },

--- a/exercises/practice/proverb/.docs/instructions.md
+++ b/exercises/practice/proverb/.docs/instructions.md
@@ -1,0 +1,19 @@
+# Instructions
+
+For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
+
+Given a list of inputs, generate the relevant proverb.
+For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
+
+```text
+For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+For want of a rider the message was lost.
+For want of a message the battle was lost.
+For want of a battle the kingdom was lost.
+And all for the want of a nail.
+```
+
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content.
+No line of the output text should be a static, unchanging string; all should vary according to the input given.

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "Adrien-LUDWIG"
+  ],
+  "files": {
+    "solution": [
+      "proverb.rkt"
+    ],
+    "test": [
+      "proverb-test.rkt"
+    ],
+    "example": [
+      ".meta/example.rkt"
+    ]
+  },
+  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/For_Want_of_a_Nail"
+}

--- a/exercises/practice/proverb/.meta/example.rkt
+++ b/exercises/practice/proverb/.meta/example.rkt
@@ -1,0 +1,16 @@
+#lang racket
+
+(provide recite)
+
+(define (recite lst)
+  (cond
+    [(empty? lst) '()]
+    [else (define (verse index)
+            (cond
+              [(= index (sub1 (length lst))) (list (format "And all for the want of a ~a." (list-ref lst 0)))]
+              [else (append
+                     (list (format "For want of a ~a the ~a was lost."
+                                   (list-ref lst index)
+                                   (list-ref lst (add1 index))))
+                     (verse (add1 index)))]))
+          (verse 0)]))

--- a/exercises/practice/proverb/.meta/tests.toml
+++ b/exercises/practice/proverb/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e974b73e-7851-484f-8d6d-92e07fe742fc]
+description = "zero pieces"
+
+[2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4]
+description = "one piece"
+
+[d9d0a8a1-d933-46e2-aa94-eecf679f4b0e]
+description = "two pieces"
+
+[c95ef757-5e94-4f0d-a6cb-d2083f5e5a83]
+description = "three pieces"
+
+[433fb91c-35a2-4d41-aeab-4de1e82b2126]
+description = "full proverb"
+
+[c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7]
+description = "four pieces modernized"

--- a/exercises/practice/proverb/proverb-test.rkt
+++ b/exercises/practice/proverb/proverb-test.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+(require "proverb.rkt")
+
+(module+ test
+  (require rackunit rackunit/text-ui)
+
+  (define suite
+    (test-suite
+     "proverb tests"
+
+     (test-equal? "zero pieces"
+                  (recite '())
+                  '())
+     (test-equal? "one piece"
+                  (recite '("nail"))
+                  '("And all for the want of a nail."))
+     (test-equal? "two pieces"
+                  (recite '("nail"  "shoe"))
+                  '("For want of a nail the shoe was lost."
+                    "And all for the want of a nail."))
+     (test-equal? "three pieces"
+                  (recite '("nail" "shoe" "horse"))
+                  '("For want of a nail the shoe was lost."
+                    "For want of a shoe the horse was lost."
+                    "And all for the want of a nail."))
+     (test-equal? "full proverb"
+                  (recite '("nail" "shoe" "horse" "rider" "message" "battle" "kingdom"))
+                  '("For want of a nail the shoe was lost."
+                    "For want of a shoe the horse was lost."
+                    "For want of a horse the rider was lost."
+                    "For want of a rider the message was lost."
+                    "For want of a message the battle was lost."
+                    "For want of a battle the kingdom was lost."
+                    "And all for the want of a nail."))
+     (test-equal? "four pieces modernized"
+                  (recite '("pin" "gun" "soldier" "battle"))
+                  '("For want of a pin the gun was lost."
+                    "For want of a gun the soldier was lost."
+                    "For want of a soldier the battle was lost."
+                    "And all for the want of a pin."))))
+
+  (run-tests suite))

--- a/exercises/practice/proverb/proverb.rkt
+++ b/exercises/practice/proverb/proverb.rkt
@@ -1,0 +1,6 @@
+#lang racket
+
+(provide recite)
+
+(define (recite lst)
+  (error "Not implemented yet"))


### PR DESCRIPTION
I had some hesitation for the formatting of `example.rkt`. What is the best option? 

- Current:
```racket
(define (recite lst)
  (cond
    [(empty? lst) '()]
    [else (define (verse index)
            (cond
              [(= index (sub1 (length lst))) (list (format "And all for the want of a ~a." (list-ref lst 0)))]
              [else (append
                     (list (format "For want of a ~a the ~a was lost."(list-ref lst index)(list-ref lst (add1 index))))
                     (verse (add1 index)))]))
          (verse 0)]))

```

- Define the inner function before `cond` to reduce indentation, but `verse` is defined even if `lst` is empty:

```racket
(define (recite lst)
  (define (verse index)
    (cond
      [(= index (sub1 (length lst))) (list (format "And all for the want of a ~a." (list-ref lst 0)))]
      [else (append
             (list (format "For want of a ~a the ~a was lost." (list-ref lst index) (list-ref lst (add1 index))))
             (verse (add1 index)))]))
  (cond
    [(empty? lst) '()]
    [else (verse 0)]))
```

- With a default argument, but we check if `lst` is empty for each value of `index` and this exposes weird usage possibilities:

```racket
(define (recite lst [index 0])
  (cond
    [(empty? lst) '()]
    [(= index (sub1 (length lst))) (list (format "And all for the want of a ~a." (list-ref lst 0)))]
    [else (append
           (list (format "For want of a ~a the ~a was lost." (list-ref lst index) (list-ref lst (add1 index))))
           (recite lst (add1 index)))]))
```