### PR TITLE
Add strain exercise (#297)

### DIFF
--- a/config.json
+++ b/config.json
@@ -512,6 +512,14 @@
         "difficulty": 1
       },
       {
+        "slug": "strain",
+        "name": "Strain",
+        "uuid": "f3c6fea7-f69e-4cc5-b71f-0d34204623a7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "darts",
         "name": "Darts",
         "uuid": "40bc0f5c-173e-4782-a4dc-c07c3e3acec6",

--- a/exercises/practice/strain/.docs/instructions.md
+++ b/exercises/practice/strain/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Instructions
+
+Implement the `keep` and `discard` operation on collections.
+Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.
+
+For example, given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the predicate:
+
+- is the number even?
+
+Then your keep operation should produce:
+
+- 2, 4
+
+While your discard operation should produce:
+
+- 1, 3, 5
+
+Note that the union of keep and discard is all the elements.
+
+The functions may be called `keep` and `discard`, or they may need different names in order to not clash with existing functions or concepts in your language.
+
+## Restrictions
+
+Keep your hands off that filter/reject/whatchamacallit functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "Adrien-LUDWIG"
+  ],
+  "files": {
+    "solution": [
+      "strain.rkt"
+    ],
+    "test": [
+      "strain-test.rkt"
+    ],
+    "example": [
+      ".meta/example.rkt"
+    ]
+  },
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
+  "source": "Conversation with James Edward Gray II",
+  "source_url": "http://graysoftinc.com/"
+}

--- a/exercises/practice/strain/.meta/example.rkt
+++ b/exercises/practice/strain/.meta/example.rkt
@@ -1,0 +1,9 @@
+#lang racket
+
+(provide keep discard)
+
+(define (keep list predicate)
+  (error "Not implemented yet"))
+
+(define (discard list predicate)
+  (error "Not implemented yet"))

--- a/exercises/practice/strain/.meta/example.rkt
+++ b/exercises/practice/strain/.meta/example.rkt
@@ -2,8 +2,10 @@
 
 (provide keep discard)
 
-(define (keep list predicate)
-  (error "Not implemented yet"))
+(define (keep lst predicate)
+  (for/list ([value lst]
+             #:when (predicate value))
+    value))
 
-(define (discard list predicate)
-  (error "Not implemented yet"))
+(define (discard lst predicate)
+  (keep lst (negate predicate)))

--- a/exercises/practice/strain/.meta/tests.toml
+++ b/exercises/practice/strain/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[26af8c32-ba6a-4eb3-aa0a-ebd8f136e003]
+description = "keep on empty list returns empty list"
+
+[f535cb4d-e99b-472a-bd52-9fa0ffccf454]
+description = "keeps everything"
+
+[950b8e8e-f628-42a8-85e2-9b30f09cde38]
+description = "keeps nothing"
+
+[92694259-6e76-470c-af87-156bdf75018a]
+description = "keeps first and last"
+
+[938f7867-bfc7-449e-a21b-7b00cbb56994]
+description = "keeps neither first nor last"
+
+[8908e351-4437-4d2b-a0f7-770811e48816]
+description = "keeps strings"
+
+[2728036b-102a-4f1e-a3ef-eac6160d876a]
+description = "keeps lists"
+
+[ef16beb9-8d84-451a-996a-14e80607fce6]
+description = "discard on empty list returns empty list"
+
+[2f42f9bc-8e06-4afe-a222-051b5d8cd12a]
+description = "discards everything"
+
+[ca990fdd-08c2-4f95-aa50-e0f5e1d6802b]
+description = "discards nothing"
+
+[71595dae-d283-48ca-a52b-45fa96819d2f]
+description = "discards first and last"
+
+[ae141f79-f86d-4567-b407-919eaca0f3dd]
+description = "discards neither first nor last"
+
+[daf25b36-a59f-4f29-bcfe-302eb4e43609]
+description = "discards strings"
+
+[a38d03f9-95ad-4459-80d1-48e937e4acaf]
+description = "discards lists"

--- a/exercises/practice/strain/strain-test.rkt
+++ b/exercises/practice/strain/strain-test.rkt
@@ -10,59 +10,63 @@
      "strain tests"
 
      (test-equal? "keep on empty list returns empty list"
-                  (keep '() "fn(x) -> true")
+                  (keep '() (lambda (x) #t))
                   '())
 
      (test-equal? "keeps everything"
-                  (keep '(1 3 5) "fn(x) -> true")
+                  (keep '(1 3 5) (lambda (x) #t))
                   '(1 3 5))
 
      (test-equal? "keeps nothing"
-                  (keep '(1 3 5) "fn(x) -> false")
+                  (keep '(1 3 5) (lambda (x) #f))
                   '())
 
      (test-equal? "keeps first and last"
-                  (keep '(1 2 3) "fn(x) -> x % 2 == 1")
+                  (keep '(1 2 3) odd?)
                   '(1 3))
 
      (test-equal? "keeps neither first nor last"
-                  (keep '(1 2 3) "fn(x) -> x % 2 == 0")
+                  (keep '(1 2 3) even?)
                   '(2))
 
      (test-equal? "keeps strings"
-                  (keep '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot") "fn(x) -> starts_with(x, 'z')")
+                  (keep '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot")
+                        (lambda (x) (equal? (string-ref x 0) #\z)))
                   '("zebra" "zombies" "zealot"))
 
      (test-equal? "keeps lists"
-                  (keep '('(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5)) "fn(x) -> contains(x, 5)")
-                  '('(5 5 5) '(5 1 2) '(1 5 2) '(1 2 5)))
+                  (keep (list '(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5))
+                        (lambda (x) (if (member 5 x) #t #f)))
+                  (list '(5 5 5) '(5 1 2) '(1 5 2) '(1 2 5)))
 
      (test-equal? "discard on empty list returns empty list"
-                  (discard '() "fn(x) -> true")
+                  (discard '() (lambda (x) #t))
                   '())
 
      (test-equal? "discards everything"
-                  (discard '(1 3 5) "fn(x) -> true")
+                  (discard '(1 3 5) (lambda (x) #t))
                   '())
 
      (test-equal? "discards nothing"
-                  (discard '(1 3 5) "fn(x) -> false")
+                  (discard '(1 3 5) (lambda (x) #f))
                   '(1 3 5))
 
      (test-equal? "discards first and last"
-                  (discard '(1 2 3) "fn(x) -> x % 2 == 1")
+                  (discard '(1 2 3) odd?)
                   '(2))
 
      (test-equal? "discards neither first nor last"
-                  (discard '(1 2 3) "fn(x) -> x % 2 == 0")
+                  (discard '(1 2 3) even?)
                   '(1 3))
 
      (test-equal? "discards strings"
-                  (discard '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot") "fn(x) -> starts_with(x, 'z')")
+                  (discard '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot")
+                           (lambda (x) (equal? (string-ref x 0) #\z)))
                   '("apple" "banana" "cherimoya"))
 
      (test-equal? "discards lists"
-                  (discard '('(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5)) "fn(x) -> contains(x, 5)")
-                  '('(1 2 3) '(2 1 2) '(2 2 1)))))
+                  (discard (list '(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5))
+                           (lambda (x) (if (member 5 x) #t #f)))
+                  (list '(1 2 3) '(2 1 2) '(2 2 1)))))
 
   (run-tests suite))

--- a/exercises/practice/strain/strain-test.rkt
+++ b/exercises/practice/strain/strain-test.rkt
@@ -1,0 +1,68 @@
+#lang racket/base
+
+(require "strain.rkt")
+
+(module+ test
+  (require rackunit rackunit/text-ui)
+
+  (define suite
+    (test-suite
+     "strain tests"
+
+     (test-equal? "keep on empty list returns empty list"
+                  (keep '() "fn(x) -> true")
+                  '())
+
+     (test-equal? "keeps everything"
+                  (keep '(1 3 5) "fn(x) -> true")
+                  '(1 3 5))
+
+     (test-equal? "keeps nothing"
+                  (keep '(1 3 5) "fn(x) -> false")
+                  '())
+
+     (test-equal? "keeps first and last"
+                  (keep '(1 2 3) "fn(x) -> x % 2 == 1")
+                  '(1 3))
+
+     (test-equal? "keeps neither first nor last"
+                  (keep '(1 2 3) "fn(x) -> x % 2 == 0")
+                  '(2))
+
+     (test-equal? "keeps strings"
+                  (keep '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot") "fn(x) -> starts_with(x, 'z')")
+                  '("zebra" "zombies" "zealot"))
+
+     (test-equal? "keeps lists"
+                  (keep '('(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5)) "fn(x) -> contains(x, 5)")
+                  '('(5 5 5) '(5 1 2) '(1 5 2) '(1 2 5)))
+
+     (test-equal? "discard on empty list returns empty list"
+                  (discard '() "fn(x) -> true")
+                  '())
+
+     (test-equal? "discards everything"
+                  (discard '(1 3 5) "fn(x) -> true")
+                  '())
+
+     (test-equal? "discards nothing"
+                  (discard '(1 3 5) "fn(x) -> false")
+                  '(1 3 5))
+
+     (test-equal? "discards first and last"
+                  (discard '(1 2 3) "fn(x) -> x % 2 == 1")
+                  '(2))
+
+     (test-equal? "discards neither first nor last"
+                  (discard '(1 2 3) "fn(x) -> x % 2 == 0")
+                  '(1 3))
+
+     (test-equal? "discards strings"
+                  (discard '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot") "fn(x) -> starts_with(x, 'z')")
+                  '("apple" "banana" "cherimoya"))
+
+     (test-equal? "discards lists"
+                  (discard '('(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5)) "fn(x) -> contains(x, 5)")
+                  '('(1 2 3) '(2 1 2) '(2 2 1)))))
+
+  (run-tests suite))

--- a/exercises/practice/strain/strain-test.rkt
+++ b/exercises/practice/strain/strain-test.rkt
@@ -11,7 +11,7 @@
 
   (define (contains-5? lst) (member 5 lst))
 
-  (define (starts-with-z? str) (equal? (string-ref str 0) #\z))
+  (define (starts-with-z? str) (char=? (string-ref str 0) #\z))
 
   (define suite
     (test-suite

--- a/exercises/practice/strain/strain-test.rkt
+++ b/exercises/practice/strain/strain-test.rkt
@@ -5,20 +5,28 @@
 (module+ test
   (require rackunit rackunit/text-ui)
 
+  (define (always-true _) #t)
+
+  (define (always-false _) #f)
+
+  (define (contains-5? lst) (member 5 lst))
+
+  (define (starts-with-z? str) (equal? (string-ref str 0) #\z))
+
   (define suite
     (test-suite
      "strain tests"
 
      (test-equal? "keep on empty list returns empty list"
-                  (keep '() (lambda (x) #t))
+                  (keep '() always-true)
                   '())
 
      (test-equal? "keeps everything"
-                  (keep '(1 3 5) (lambda (x) #t))
+                  (keep '(1 3 5) always-true)
                   '(1 3 5))
 
      (test-equal? "keeps nothing"
-                  (keep '(1 3 5) (lambda (x) #f))
+                  (keep '(1 3 5) always-false)
                   '())
 
      (test-equal? "keeps first and last"
@@ -31,24 +39,24 @@
 
      (test-equal? "keeps strings"
                   (keep '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot")
-                        (lambda (x) (equal? (string-ref x 0) #\z)))
+                        starts-with-z?)
                   '("zebra" "zombies" "zealot"))
 
      (test-equal? "keeps lists"
                   (keep (list '(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5))
-                        (lambda (x) (if (member 5 x) #t #f)))
+                        contains-5?)
                   (list '(5 5 5) '(5 1 2) '(1 5 2) '(1 2 5)))
 
      (test-equal? "discard on empty list returns empty list"
-                  (discard '() (lambda (x) #t))
+                  (discard '() always-true)
                   '())
 
      (test-equal? "discards everything"
-                  (discard '(1 3 5) (lambda (x) #t))
+                  (discard '(1 3 5) always-true)
                   '())
 
      (test-equal? "discards nothing"
-                  (discard '(1 3 5) (lambda (x) #f))
+                  (discard '(1 3 5) always-false)
                   '(1 3 5))
 
      (test-equal? "discards first and last"
@@ -61,12 +69,12 @@
 
      (test-equal? "discards strings"
                   (discard '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot")
-                           (lambda (x) (equal? (string-ref x 0) #\z)))
+                           starts-with-z?)
                   '("apple" "banana" "cherimoya"))
 
      (test-equal? "discards lists"
                   (discard (list '(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5))
-                           (lambda (x) (if (member 5 x) #t #f)))
+                           contains-5?)
                   (list '(1 2 3) '(2 1 2) '(2 2 1)))))
 
   (run-tests suite))

--- a/exercises/practice/strain/strain.rkt
+++ b/exercises/practice/strain/strain.rkt
@@ -1,0 +1,9 @@
+#lang racket
+
+(provide keep discard)
+
+(define (keep list predicate)
+  (error "Not implemented yet"))
+
+(define (discard list predicate)
+  (error "Not implemented yet"))

--- a/exercises/practice/strain/strain.rkt
+++ b/exercises/practice/strain/strain.rkt
@@ -2,8 +2,8 @@
 
 (provide keep discard)
 
-(define (keep list predicate)
+(define (keep lst predicate)
   (error "Not implemented yet"))
 
-(define (discard list predicate)
+(define (discard lst predicate)
   (error "Not implemented yet"))


### PR DESCRIPTION
Are these two lambda acceptable? These are the predicates given to the tested function.
For the latter, is it ok to use `list` in this case? The lambda doesn't work with the quote form.

```racket
     (test-equal? "keeps strings"
                  (keep '("apple" "zebra" "banana" "zombies" "cherimoya" "zealot")
                        (lambda (x) (equal? (string-ref x 0) #\z)))
                  '("zebra" "zombies" "zealot"))

     (test-equal? "keeps lists"
                  (keep (list '(1 2 3) '(5 5 5) '(5 1 2) '(2 1 2) '(1 5 2) '(2 2 1) '(1 2 5))
                        (lambda (x) (if (member 5 x) #t #f)))
                  (list '(5 5 5) '(5 1 2) '(1 5 2) '(1 2 5)))
```