### PR TITLE
Sync phone-number tests

### DIFF
--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -20,6 +20,11 @@ description = "cleans numbers with multiple spaces"
 
 [598d8432-0659-4019-a78b-1c6a73691d21]
 description = "invalid when 9 digits"
+include = false
+
+[2de74156-f646-42b5-8638-0ef1d8b58bc2]
+description = "invalid when 9 digits"
+reimplements = "598d8432-0659-4019-a78b-1c6a73691d21"
 
 [57061c72-07b5-431f-9766-d97da7c4399d]
 description = "invalid when 11 digits does not start with a 1"
@@ -32,12 +37,27 @@ description = "valid when 11 digits and starting with 1 even with punctuation"
 
 [c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
 description = "invalid when more than 11 digits"
+include = false
+
+[4a1509b7-8953-4eec-981b-c483358ff531]
+description = "invalid when more than 11 digits"
+reimplements = "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad"
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
+include = false
+
+[eb8a1fc0-64e5-46d3-b0c6-33184208e28a]
+description = "invalid with letters"
+reimplements = "63f38f37-53f6-4a5f-bd86-e9b404f10a60"
 
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
+include = false
+
+[065f6363-8394-4759-b080-e6c8c351dd1f]
+description = "invalid with punctuations"
+reimplements = "4bd97d90-52fd-45d3-b0db-06ab95b1244e"
 
 [d77d07f8-873c-4b17-8978-5f66139bf7d7]
 description = "invalid if area code starts with 0"

--- a/exercises/practice/phone-number/phone-number-test.rkt
+++ b/exercises/practice/phone-number/phone-number-test.rkt
@@ -48,12 +48,12 @@
      (test-exn "invalid with letters"
                exn:fail?
                (λ ()
-                 (nanp-clean "123-abc-7890")))
+                 (nanp-clean "523-abc-7890")))
 
      (test-exn "invalid with punctuations"
                exn:fail?
                (λ ()
-                 (nanp-clean "123-@:!-7890")))
+                 (nanp-clean "523-@:!-7890")))
 
      (test-exn "invalid if area code starts with 0"
                exn:fail?


### PR DESCRIPTION
Related to #274

The Racket track typically doesn't check for a specific exception message since often a student may opt to use a contract instead. Often a contract violation might more useful than a custom exception message so there's no reason to force students one way or the other. 

I did update the two tests where inputs changed though.