### PR TITLE
binary-search: use vectors instead of lists for the sorted-data

### DIFF
--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "Adrien-LUDWIG"
   ],
+  "contributors": [
+    "dreig"
+  ],
   "files": {
     "solution": [
       "binary-search.rkt"

--- a/exercises/practice/binary-search/.meta/example.rkt
+++ b/exercises/practice/binary-search/.meta/example.rkt
@@ -2,13 +2,12 @@
 
 (provide binary-search)
 
-(define (binary-search array value)
-  (define (rec left right)
+(define (binary-search array target)
+  (let loop ([lo 0] [hi (vector-length array)])
+    (define mid (quotient (+ lo hi) 2))
     (cond
-      [(> left right) (error "Value not in array")]
-      [else (define mid (+ left (quotient (- right left) 2)))
-            (cond
-              [(< value (list-ref array mid)) (rec left (sub1 mid))]
-              [(< (list-ref array mid) value) (rec (add1 mid) right)]
-              [else mid])]))
-  (rec 0 (sub1 (length array))))
+      [(= lo hi) (and (< lo (vector-length array))
+                      (= (vector-ref array lo) target)
+                      lo)]
+      [(< (vector-ref array mid) target) (loop (+ 1 mid) hi)]
+      [else (loop lo mid)])))

--- a/exercises/practice/binary-search/binary-search-test.rkt
+++ b/exercises/practice/binary-search/binary-search-test.rkt
@@ -10,37 +10,37 @@
      "binary-search tests"
 
      (test-eqv? "finds a value in an array with one element"
-                (binary-search '(6) 6)
+                (binary-search #(6) 6)
                 0)
      (test-eqv? "finds a value in the middle of an array"
-                (binary-search '(1 3 4 6 8 9 11) 6)
+                (binary-search #(1 3 4 6 8 9 11) 6)
                 3)
      (test-eqv? "finds a value at the beginning of an array"
-                (binary-search '(1 3 4 6 8 9 11) 1)
+                (binary-search #(1 3 4 6 8 9 11) 1)
                 0)
      (test-eqv? "finds a value at the end of an array"
-                (binary-search '(1 3 4 6 8 9 11) 11)
+                (binary-search #(1 3 4 6 8 9 11) 11)
                 6)
      (test-eqv? "finds a value in an array of odd length"
-                (binary-search '(1 3 5 8 13 21 34 55 89 144 233 377 634) 144)
+                (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377 634) 144)
                 9)
      (test-eqv? "finds a value in an array of even length"
-                (binary-search '(1 3 5 8 13 21 34 55 89 144 233 377) 21)
+                (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377) 21)
                 5)
-     (test-exn "identifies that a value is not included in the array"
-               exn:fail?
-               (lambda () (binary-search '(1 3 4 6 8 9 11) 7)))
-     (test-exn "a value smaller than the array's smallest value is not found"
-               exn:fail?
-               (lambda () (binary-search '(1 3 4 6 8 9 11) 0)))
-     (test-exn "a value larger than the array's smallest value is not found"
-               exn:fail?
-               (lambda () (binary-search '(1 3 4 6 8 9 11) 13)))
-     (test-exn "nothing is found in an empty array"
-               exn:fail?
-               (lambda () (binary-search '() 1)))
-     (test-exn "nothing is found when the left and right bounds cross"
-               exn:fail?
-               (lambda () (binary-search '(1 2) 0)))))
+     (test-eqv? "identifies that a value is not included in the array"
+               (binary-search #(1 3 4 6 8 9 11) 7)
+               #f)
+     (test-eqv? "a value smaller than the array's smallest value is not found"
+               (binary-search #(1 3 4 6 8 9 11) 0)
+               #f)
+     (test-eqv? "a value larger than the array's smallest value is not found"
+               (binary-search #(1 3 4 6 8 9 11) 13)
+               #f)
+     (test-eqv? "nothing is found in an empty array"
+               (binary-search #() 1)
+               #f)
+     (test-eqv? "nothing is found when the left and right bounds cross"
+               (binary-search #(1 2) 0)
+               #f)))
 
   (run-tests suite))


### PR DESCRIPTION
Additionally, I decided to go ahead and make it return `#f` when the target is not found instead of throwing an error, which is more in line with how the exercise is implemented in other tracks (Common Lisp, Scheme) and `vector-binary-search` in srfi-43: https://docs.racket-lang.org/srfi/srfi-std/srfi-43.html#vector-binary-search

If this later change is not ok, I will revert it.

addresses #323