### PR TITLE
Update collatz-conjecture tests to allow use of contract

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/example.rkt
+++ b/exercises/practice/collatz-conjecture/.meta/example.rkt
@@ -10,11 +10,6 @@
                           (add1 (* 3 n)))
                       (add1 acc))))
 
-(define (collatz n)
-  (if (nand (exact-integer? n)
-            (positive? n))
-      (error "Only positive integers are allowed")
-      (collatz-length n)))
-  
-
-  
+(define/contract (collatz n)
+  (-> exact-positive-integer? exact-integer?)
+  (collatz-length n))

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.rkt
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.rkt
@@ -5,11 +5,6 @@
 (module+ test
   (require rackunit rackunit/text-ui)
 
-  (define (exn-msg-matches? msg f)
-    (with-handlers ([exn:fail? (lambda (exn)
-                                 (string=? (exn-message exn) msg))])
-      (f)))
-
   (define suite
     (test-suite
      "collatz conjecture tests"
@@ -30,19 +25,16 @@
                 (collatz 1000000)
                 152)
 
-     (test-true "zero is an error"
-                (exn-msg-matches?
-                  "Only positive integers are allowed"
-                  (lambda () (collatz 0))))
+     (test-exn "zero is an error"
+                exn:fail?
+                (lambda () (collatz 0)))
 
-     (test-true "negative value is an error"
-                (exn-msg-matches?
-                  "Only positive integers are allowed"
-                  (lambda () (collatz -15))))
+     (test-exn "negative value is an error"
+                exn:fail?
+                (lambda () (collatz -15)))
 
-     (test-true "non exact value is an error"
-                (exn-msg-matches?
-                  "Only positive integers are allowed"
-                  (lambda () (collatz 3.4))))))
+     (test-exn "non exact value is an error"
+                exn:fail?
+                (lambda () (collatz 3.4)))))
 
 (run-tests suite))


### PR DESCRIPTION
The previous iteration was strict on testing for a particular error message. This change allows students to idiomatically define a contract on `collatz`, and it won't break solutions that previously passed the last iteration.