### PR TITLE
Bump CI to Racket 8.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         racket-variant: ['BC', 'CS']
-        racket-version: ['8.9', '8.10', '8.11']
+        racket-version: ['8.10', '8.11', '8.12']
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
Once exercism/racket-test-runner#69 is merged, we should update the CI here as well.