### PR TITLE
Grade school for Racket

### DIFF
--- a/config.json
+++ b/config.json
@@ -702,6 +702,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7
+      },
+      {
+        "slug": "grade-school",
+        "name": "Grade School",
+        "uuid": "60a91b4c-5be0-4e54-8d93-df230c259866",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
       }
     ]
   },

--- a/exercises/practice/grade-school/.docs/instructions.md
+++ b/exercises/practice/grade-school/.docs/instructions.md
@@ -1,0 +1,21 @@
+# Instructions
+
+Given students' names along with the grade that they are in, create a roster for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.
+  Grades should sort as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Let me think.
+    We have Anna, Barb, and Charlie in grade 1, Alex, Peter, and Zoe in grade 2 and Jim in grade 5.
+    So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
+
+Note that all our students only have one name (It's a small town, what do you want?) and each student cannot be added more than once to a grade or the roster.
+In fact, when a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,0 +1,16 @@
+{
+  "authors": ["blakelewis"],
+  "files": {
+    "solution": [
+      "grade-school.rkt"
+    ],
+    "test": [
+      "grade-school-test.rkt"
+    ],
+    "example": [
+      ".meta/example.rkt"
+    ]
+  },
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school.",
+  "source": "A pairing session with Phil Battos at gSchool"
+}

--- a/exercises/practice/grade-school/.meta/example.rkt
+++ b/exercises/practice/grade-school/.meta/example.rkt
@@ -1,0 +1,25 @@
+#lang racket
+
+(provide school%)
+
+(define school%
+  (class object%
+    (super-new)
+    (define students (mutable-set))
+    (define grade-list (make-hash))
+
+    (define/public (add name grade)
+      (and
+        (not (set-member? students name))
+        (begin
+          (set-add! students name)
+          (let* ([current (hash-ref grade-list grade '())]
+                 [updated (sort (cons name current) string<?)])
+             (hash-set! grade-list grade updated))
+          #t)))
+
+     (define/public (grade g)
+       (hash-ref grade-list g '()))
+
+     (define/public (roster)
+       (sort (hash->list grade-list) < #:key car))))

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,0 +1,86 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a3f0fb58-f240-4723-8ddc-e644666b85cc]
+description = "Roster is empty when no student is added"
+
+[9337267f-7793-4b90-9b4a-8e3978408824]
+description = "Add a student"
+
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Student is added to the roster"
+
+[73c3ca75-0c16-40d7-82f5-ed8fe17a8e4a]
+description = "Adding multiple students in the same grade in the roster"
+
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Multiple students in the same grade are added to the roster"
+
+[87c871c1-6bde-4413-9c44-73d59a259d83]
+description = "Cannot add student to same grade in the roster more than once"
+
+[c125dab7-2a53-492f-a99a-56ad511940d8]
+description = "A student can't be in two different grades"
+include = false
+
+[a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1]
+description = "A student can only be added to the same grade in the roster once"
+include = false
+reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
+
+[d7982c4f-1602-49f6-a651-620f2614243a]
+description = "Student not added to same grade in the roster more than once"
+reimplements = "a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1"
+
+[e70d5d8f-43a9-41fd-94a4-1ea0fa338056]
+description = "Adding students in multiple grades"
+
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Students in multiple grades are added to the roster"
+
+[7df542f1-57ce-433c-b249-ff77028ec479]
+description = "Cannot add same student to multiple grades in the roster"
+
+[6a03b61e-1211-4783-a3cc-fc7f773fba3f]
+description = "A student cannot be added to more than one grade in the sorted roster"
+include = false
+reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
+
+[c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5]
+description = "Student not added to multiple grades in the roster"
+reimplements = "6a03b61e-1211-4783-a3cc-fc7f773fba3f"
+
+[d9af4f19-1ba1-48e7-94d0-dabda4e5aba6]
+description = "Students are sorted by grades in the roster"
+
+[d9fb5bea-f5aa-4524-9d61-c158d8906807]
+description = "Students are sorted by name in the roster"
+
+[180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
+description = "Students are sorted by grades and then by name in the roster"
+
+[5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
+description = "Grade is empty if no students in the roster"
+
+[1e0cf06b-26e0-4526-af2d-a2e2df6a51d6]
+description = "Grade is empty if no students in that grade"
+
+[2bfc697c-adf2-4b65-8d0f-c46e085f796e]
+description = "Student not added to same grade more than once"
+
+[66c8e141-68ab-4a04-a15a-c28bc07fe6b9]
+description = "Student not added to multiple grades"
+
+[c9c1fc2f-42e0-4d2c-b361-99271f03eda7]
+description = "Student not added to other grade for multiple grades"
+
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Students are sorted by name in a grade"

--- a/exercises/practice/grade-school/grade-school-test.rkt
+++ b/exercises/practice/grade-school/grade-school-test.rkt
@@ -46,22 +46,6 @@
         (check-false (send school add "James" 2))
         (check-true (send school add "Paul" 2)))
 
-      (test-case "A student can't be in two different grades"
-	(define school (new school%))
-        (check-true (send school add "Aimee" 2))
-        (check-false (send school add "Aimee" 1))
-        (check-equal?
-	 (send school roster)
-	 '((2 "Aimee"))))
-
-      (test-case "A student can only be added to the same grade in the roster once"
-	(define school (new school%))
-        (check-true (send school add "Aimee" 2))
-        (check-false (send school add "Aimee" 2))
-        (check-equal?
-	 (send school roster)
-	 '((2 "Aimee"))))
-
       (test-case "Student not added to same grade in the roster more than once"
 	(define school (new school%))
         (check-true (send school add "Blair" 2))
@@ -91,14 +75,6 @@
         (check-true (send school add "James" 2))
         (check-false (send school add "James" 3))
         (check-true (send school add "Paul" 3)))
-
-      (test-case "A student cannot be added to more than one grade in the sorted roster"
-	(define school (new school%))
-          (check-true (send school add "Aimee" 2))
-          (check-false (send school add "Aimee" 1))
-          (check-equal?
-	   (send school roster)
-	   '((2 "Aimee"))))
 
       (test-case "Student not added to multiple grades in the roster"
 	(define school (new school%))

--- a/exercises/practice/grade-school/grade-school-test.rkt
+++ b/exercises/practice/grade-school/grade-school-test.rkt
@@ -1,0 +1,195 @@
+#lang racket/base
+
+(require racket/class)
+(require "grade-school.rkt")
+
+(module+ test
+  (require rackunit rackunit/text-ui))
+
+(module+ test
+  (define suite
+    (test-suite "grade school tests"
+      (test-case "Roster is empty when no student is added"
+	(define school (new school%))
+        (check-equal? (send school roster) '()))
+
+      (test-case "Add a student"
+	(define school (new school%))
+        (check-true (send school add "Aimee" 2)))
+
+      (test-case "Student is added to the roster"
+	(define school (new school%))
+        (check-true (send school add "Aimee" 2))
+	(check-equal?
+          (send school roster)
+	  '((2 "Aimee"))))
+
+      (test-case "Adding multiple students in the same grade in the roster"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-true (send school add "Paul" 2)))
+
+      (test-case "Multiple students in the same grade are added to the roster"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-true (send school add "Paul" 2))
+        (check-equal?
+	  (send school roster)
+	  '((2 "Blair" "James" "Paul"))))
+
+      (test-case "Cannot add student to same grade in the roster more than once"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false (send school add "James" 2))
+        (check-true (send school add "Paul" 2)))
+
+      (test-case "A student can't be in two different grades"
+	(define school (new school%))
+        (check-true (send school add "Aimee" 2))
+        (check-false (send school add "Aimee" 1))
+        (check-equal?
+	 (send school roster)
+	 '((2 "Aimee"))))
+
+      (test-case "A student can only be added to the same grade in the roster once"
+	(define school (new school%))
+        (check-true (send school add "Aimee" 2))
+        (check-false (send school add "Aimee" 2))
+        (check-equal?
+	 (send school roster)
+	 '((2 "Aimee"))))
+
+      (test-case "Student not added to same grade in the roster more than once"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false (send school add "James" 2))
+        (check-true (send school add "Paul" 2))
+        (check-equal?
+	 (send school roster)
+	 '((2 "Blair" "James" "Paul"))))
+
+      (test-case "Adding students in multiple grades"
+	(define school (new school%))
+        (check-true (send school add "Chelsea" 3))
+        (check-true (send school add "Logan" 7)))
+
+      (test-case "Students in multiple grades are added to the roster"
+	(define school (new school%))
+        (check-true (send school add "Chelsea" 3))
+        (check-true (send school add "Logan" 7))
+        (check-equal?
+	 (send school roster)
+	 '((3 "Chelsea") (7 "Logan"))))
+
+      (test-case "Cannot add same student to multiple grades in the roster"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false (send school add "James" 3))
+        (check-true (send school add "Paul" 3)))
+
+      (test-case "A student cannot be added to more than one grade in the sorted roster"
+	(define school (new school%))
+          (check-true (send school add "Aimee" 2))
+          (check-false (send school add "Aimee" 1))
+          (check-equal?
+	   (send school roster)
+	   '((2 "Aimee"))))
+
+      (test-case "Student not added to multiple grades in the roster"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false(send school add "James" 3))
+        (check-true (send school add "Paul" 3))
+        (check-equal?
+	 (send school roster)
+	 '((2 "Blair" "James") (3 "Paul"))))
+
+      (test-case "Students are sorted by grades in the roster"
+	(define school (new school%))
+        (check-true (send school add "Jim" 3))
+        (check-true (send school add "Peter" 2))
+        (check-true (send school add "Anna" 1))
+        (check-equal?
+	 (send school roster)
+	 '((1 "Anna") (2 "Peter") (3 "Jim"))))
+
+      (test-case "Students are sorted by name in the roster"
+	(define school (new school%))
+        (check-true (send school add "Peter" 2))
+        (check-true (send school add "Zoe" 2))
+        (check-true (send school add "Alex" 2))
+        (check-equal?
+          (send school roster)
+          '((2 "Alex" "Peter" "Zoe"))))
+
+      (test-case "Students are sorted by grades and then by name in the roster"
+	(define school (new school%))
+        (check-true (send school add "Peter" 2))
+        (check-true (send school add "Anna" 1))
+        (check-true (send school add "Barb" 1))
+        (check-true (send school add "Zoe" 2))
+        (check-true (send school add "Alex" 2))
+        (check-true (send school add "Jim" 3))
+        (check-true (send school add "Charlie" 1))
+        (check-equal?
+	 (send school roster)
+	 '((1 "Anna" "Barb" "Charlie") (2 "Alex" "Peter" "Zoe") (3 "Jim"))))
+
+      (test-case "Grade is empty if no students in the roster"
+	(define school (new school%))
+        (check-equal? (send school grade 1) '()))
+
+      (test-case "Grade is empty if no students in that grade"
+	(define school (new school%))
+        (check-true (send school add "Peter" 2))
+        (check-true (send school add "Zoe" 2))
+        (check-true (send school add "Alex" 2))
+        (check-true (send school add "Jim" 3))
+        (check-equal? (send school grade 1) '()))
+
+      (test-case "Student not added to same grade more than once"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false (send school add "James" 2))
+        (check-true (send school add "Paul" 2))
+        (check-equal?
+	 (send school grade 2)
+         '("Blair" "James" "Paul")))
+
+      (test-case "Student not added to multiple grades"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false (send school add "James" 3))
+        (check-true (send school add "Paul" 3))
+        (check-equal?
+	 (send school grade 2)
+         '("Blair" "James")))
+
+      (test-case "Student not added to other grade for multiple grades"
+	(define school (new school%))
+        (check-true (send school add "Blair" 2))
+        (check-true (send school add "James" 2))
+        (check-false (send school add "James" 3))
+        (check-true (send school add "Paul" 3))
+        (check-equal?
+	 (send school grade 3)
+         '("Paul")))
+
+      (test-case "Students are sorted by name in a grade"
+	(define school (new school%))
+        (check-true (send school add "Franklin" 5))
+        (check-true (send school add "Bradley" 5))
+        (check-true (send school add "Jeff" 1))
+        (check-equal?
+	 (send school grade 5)
+         '("Bradley" "Franklin")))))
+
+  (run-tests suite))

--- a/exercises/practice/grade-school/grade-school.rkt
+++ b/exercises/practice/grade-school/grade-school.rkt
@@ -1,0 +1,7 @@
+#lang racket
+
+(provide school%)
+
+(define school%
+  (class object%
+    (error "Not implemented yet")))


### PR DESCRIPTION
This exercise is kind of a mess.  The instructions are vague and I see a lot of variabilty among the different implementations. The canonical data indicates that the roster should throw away the grade levels, but following the example of C++, I have retained them in hash->list format. One of the tests seems flat wrong, and I noticed that other languages skipped it, but I have fixed it to match what seems to be its intent.