### PR TITLE
Update binary search

### DIFF
--- a/exercises/practice/binary-search/.docs/instructions.append.md
+++ b/exercises/practice/binary-search/.docs/instructions.append.md
@@ -1,0 +1,6 @@
+# Instructions append
+
+In Racket, this exercise uses sorted [vectors] rather than lists because vectors support constant-time access of its elements. Like several other Lisp tracks, when an item isn't present in the vector, the expectation is that the [Boolean literal `#f`][booleans] will be returned rather than raising an exception. 
+
+[vectors]: https://docs.racket-lang.org/guide/vectors.html
+[booleans]: https://docs.racket-lang.org/reference/booleans.html

--- a/exercises/practice/binary-search/binary-search-test.rkt
+++ b/exercises/practice/binary-search/binary-search-test.rkt
@@ -12,33 +12,43 @@
      (test-eqv? "finds a value in a vector with one element"
                 (binary-search #(6) 6)
                 0)
+
      (test-eqv? "finds a value in the middle of a vector"
                 (binary-search #(1 3 4 6 8 9 11) 6)
                 3)
+
      (test-eqv? "finds a value at the beginning of a vector"
                 (binary-search #(1 3 4 6 8 9 11) 1)
                 0)
+
      (test-eqv? "finds a value at the end of a vector"
                 (binary-search #(1 3 4 6 8 9 11) 11)
                 6)
+
      (test-eqv? "finds a value in a vector of odd length"
                 (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377 634) 144)
                 9)
+
      (test-eqv? "finds a value in a vector of even length"
                 (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377) 21)
                 5)
+
      (test-eqv? "identifies that a value is not included in the vector"
                (binary-search #(1 3 4 6 8 9 11) 7)
                #f)
+
      (test-eqv? "a value smaller than the vector's smallest value is not found"
                (binary-search #(1 3 4 6 8 9 11) 0)
                #f)
+
      (test-eqv? "a value larger than the vector's largest value is not found"
                (binary-search #(1 3 4 6 8 9 11) 13)
                #f)
+
      (test-eqv? "nothing is found in an empty vector"
                (binary-search #() 1)
                #f)
+
      (test-eqv? "nothing is found when the left and right bounds cross"
                (binary-search #(1 2) 0)
                #f)))

--- a/exercises/practice/binary-search/binary-search-test.rkt
+++ b/exercises/practice/binary-search/binary-search-test.rkt
@@ -33,24 +33,19 @@
                 (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377) 21)
                 5)
 
-     (test-eqv? "identifies that a value is not included in the vector"
-               (binary-search #(1 3 4 6 8 9 11) 7)
-               #f)
+     (test-false "identifies that a value is not included in the vector"
+               (binary-search #(1 3 4 6 8 9 11) 7))
 
-     (test-eqv? "a value smaller than the vector's smallest value is not found"
-               (binary-search #(1 3 4 6 8 9 11) 0)
-               #f)
+     (test-false "a value smaller than the vector's smallest value is not found"
+               (binary-search #(1 3 4 6 8 9 11) 0))
 
-     (test-eqv? "a value larger than the vector's largest value is not found"
-               (binary-search #(1 3 4 6 8 9 11) 13)
-               #f)
+     (test-false "a value larger than the vector's largest value is not found"
+               (binary-search #(1 3 4 6 8 9 11) 13))
 
-     (test-eqv? "nothing is found in an empty vector"
-               (binary-search #() 1)
-               #f)
+     (test-false "nothing is found in an empty vector"
+               (binary-search #() 1))
 
-     (test-eqv? "nothing is found when the left and right bounds cross"
-               (binary-search #(1 2) 0)
-               #f)))
+     (test-false "nothing is found when the left and right bounds cross"
+               (binary-search #(1 2) 0))))
 
   (run-tests suite))

--- a/exercises/practice/binary-search/binary-search-test.rkt
+++ b/exercises/practice/binary-search/binary-search-test.rkt
@@ -9,34 +9,34 @@
     (test-suite
      "binary-search tests"
 
-     (test-eqv? "finds a value in an array with one element"
+     (test-eqv? "finds a value in a vector with one element"
                 (binary-search #(6) 6)
                 0)
-     (test-eqv? "finds a value in the middle of an array"
+     (test-eqv? "finds a value in the middle of a vector"
                 (binary-search #(1 3 4 6 8 9 11) 6)
                 3)
-     (test-eqv? "finds a value at the beginning of an array"
+     (test-eqv? "finds a value at the beginning of a vector"
                 (binary-search #(1 3 4 6 8 9 11) 1)
                 0)
-     (test-eqv? "finds a value at the end of an array"
+     (test-eqv? "finds a value at the end of a vector"
                 (binary-search #(1 3 4 6 8 9 11) 11)
                 6)
-     (test-eqv? "finds a value in an array of odd length"
+     (test-eqv? "finds a value in a vector of odd length"
                 (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377 634) 144)
                 9)
-     (test-eqv? "finds a value in an array of even length"
+     (test-eqv? "finds a value in a vector of even length"
                 (binary-search #(1 3 5 8 13 21 34 55 89 144 233 377) 21)
                 5)
-     (test-eqv? "identifies that a value is not included in the array"
+     (test-eqv? "identifies that a value is not included in the vector"
                (binary-search #(1 3 4 6 8 9 11) 7)
                #f)
-     (test-eqv? "a value smaller than the array's smallest value is not found"
+     (test-eqv? "a value smaller than the vector's smallest value is not found"
                (binary-search #(1 3 4 6 8 9 11) 0)
                #f)
-     (test-eqv? "a value larger than the array's smallest value is not found"
+     (test-eqv? "a value larger than the vector's largest value is not found"
                (binary-search #(1 3 4 6 8 9 11) 13)
                #f)
-     (test-eqv? "nothing is found in an empty array"
+     (test-eqv? "nothing is found in an empty vector"
                (binary-search #() 1)
                #f)
      (test-eqv? "nothing is found when the left and right bounds cross"


### PR DESCRIPTION
I've added an instructions append to clarify that sorted vectors are being used instead of lists. I've also replaced references to arrays in the test suite. I did some minor formatting and converted a few of the `(test-eqv ... #f)`  tests to the simpler `(test-false ...)` tests