### PR TITLE
Bump CI to Racket 8.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         racket-variant: ['BC', 'CS']
-        racket-version: ['8.10', '8.11', '8.12']
+        racket-version: ['8.11', '8.12', '8.13']
 
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29


### PR DESCRIPTION
Racket 8.13 was released two days ago and is already available as a snapshot for CI purposes. The test runner will need to wait a few days for a Docker image of 8.13.