### PR TITLE
Bump racket CI to 8.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         racket-variant: ['BC', 'CS']
-        racket-version: ['8.11', '8.12', '8.13']
+        racket-version: ['8.12', '8.13', '8.14']
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
Bump the CI to the latest Racket version released this month.