### PR TITLE
Fix robot-name tests

### DIFF
--- a/exercises/practice/robot-name/robot-name-test.rkt
+++ b/exercises/practice/robot-name/robot-name-test.rkt
@@ -9,7 +9,7 @@
 
   (define max-names (* 26 26 10 10 10))
 
-  (define proper-robot-name #px"\\p{Lu}{2}\\p{Nd}{3}")
+  (define proper-robot-name #px"^\\p{Lu}{2}\\p{Nd}{3}$")
 
   (define (check-proper-robot-name r)
     (check-regexp-match proper-robot-name (name r)))
@@ -28,20 +28,20 @@
              [name1 (name robby)]
              [_ (reset! robby)]
              [name2 (name robby)])
-        (and
-         (and (check-regexp-match proper-robot-name name1)
-              (check-regexp-match proper-robot-name name2))
-         (not (string=? name1 name2)))))
+        (check-regexp-match proper-robot-name name1)
+        (check-regexp-match proper-robot-name name2)
+        (check-not-equal? name1 name2)))
 
      ;; reset cache in order to generate all the names
      (test-case
       "Check that robots are created with unique names."
-      (begin
+      (let ([count (/ max-names 4)])
         (reset-name-cache!)
-        (= max-names
-           (let ([names (make-hash)])
-             (for ((_ (in-range (/ max-names 4))))
-               (hash-set! names (name (make-robot)) #t))
-             (hash-count names)))))))
+        (check-equal?
+         (let ([names (make-hash)])
+           (for ((_ (in-range count)))
+             (hash-set! names (name (make-robot)) #t))
+           (hash-count names))
+         count)))))
 
-    (run-tests robot-name-suite))
+  (run-tests robot-name-suite))

--- a/exercises/practice/robot-name/robot-name-test.rkt
+++ b/exercises/practice/robot-name/robot-name-test.rkt
@@ -32,10 +32,11 @@
         (check-regexp-match proper-robot-name name2)
         (check-not-equal? name1 name2)))
 
-     ;; reset cache in order to generate all the names
      (test-case
       "Check that robots are created with unique names."
-      (let ([count (/ max-names 4)])
+      ;; sufficient to cause collision (birthday paradox)
+      (let ([count 5000])
+        ;; reset cache in order to generate all the names
         (reset-name-cache!)
         (check-equal?
          (let ([names (make-hash)])


### PR DESCRIPTION
The regex also matched on sub strings.
The other tests did not do anything because they only returned a boolean instead of using `check` from rackunit.