### PR TITLE
Update CI to Racket 8.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     name: Racket ${{ matrix.racket-version }}-${{ matrix.racket-variant }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         racket-variant: ['BC', 'CS']
-        racket-version: ['8.12', '8.13', '8.14']
+        racket-version: ['8.13', '8.14', '8.15']
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938


### PR DESCRIPTION
The test runner will also need to be updated once the 8.15 image is available.