### PR TITLE
Update CI to Racket 8.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         racket-variant: ['BC', 'CS']
-        racket-version: ['8.13', '8.14', '8.15']
+        racket-version: ['8.14', '8.15', '8.16']
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Related to https://github.com/exercism/racket-test-runner/pull/87