### PR TITLE
Sync problem-specs docs

### DIFF
--- a/exercises/practice/luhn/.docs/instructions.md
+++ b/exercises/practice/luhn/.docs/instructions.md
@@ -41,7 +41,7 @@ If the sum is evenly divisible by 10, the original number is valid.
 
 ### Invalid Canadian SIN
 
-The number to be checked is `066 123 468`.
+The number to be checked is `066 123 478`.
 
 We start at the end of the number and double every second digit, beginning with the second digit from the right and moving left.
 

--- a/exercises/practice/protein-translation/.docs/instructions.md
+++ b/exercises/practice/protein-translation/.docs/instructions.md
@@ -1,36 +1,17 @@
 # Instructions
 
-Translate RNA sequences into proteins.
+Your job is to translate RNA sequences into proteins.
 
-RNA can be broken into three-nucleotide sequences called codons, and then translated to a protein like so:
+RNA strands are made up of three-nucleotide sequences called **codons**.
+Each codon translates to an **amino acid**.
+When joined together, those amino acids make a protein.
 
-RNA: `"AUGUUUUCU"` => translates to
-
-Codons: `"AUG", "UUU", "UCU"`
-=> which become a protein with the following sequence =>
-
-Protein: `"Methionine", "Phenylalanine", "Serine"`
-
-There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
-If it works for one codon, the program should work for all of them.
-However, feel free to expand the list in the test suite to include them all.
-
-There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
-
-All subsequent codons after are ignored, like this:
-
-RNA: `"AUGUUUUCUUAAAUG"` =>
-
-Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
-
-Protein: `"Methionine", "Phenylalanine", "Serine"`
-
-Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
-
-Below are the codons and resulting amino acids needed for the exercise.
+In the real world, there are 64 codons, which in turn correspond to 20 amino acids.
+However, for this exercise, you’ll only use a few of the possible 64.
+They are listed below:
 
 | Codon              | Amino Acid    |
-| :----------------- | :------------ |
+| ------------------ | ------------- |
 | AUG                | Methionine    |
 | UUU, UUC           | Phenylalanine |
 | UUA, UUG           | Leucine       |
@@ -39,6 +20,18 @@ Below are the codons and resulting amino acids needed for the exercise.
 | UGU, UGC           | Cysteine      |
 | UGG                | Tryptophan    |
 | UAA, UAG, UGA      | STOP          |
+
+For example, the RNA string “AUGUUUUCU” has three codons: “AUG”, “UUU” and “UCU”.
+These map to Methionine, Phenylalanine, and Serine.
+
+## “STOP” Codons
+
+You’ll note from the table above that there are three **“STOP” codons**.
+If you encounter any of these codons, ignore the rest of the sequence — the protein is complete.
+
+For example, “AUGUUUUCUUAAAUG” contains a STOP codon (“UAA”).
+Once we reach that point, we stop processing.
+We therefore only consider the part before it (i.e. “AUGUUUUCU”), not any further codons after it (i.e. “AUG”).
 
 Learn more about [protein translation on Wikipedia][protein-translation].
 


### PR DESCRIPTION
I'm taking care of the docs first and then some of the missing tests separately for `anagram`, `reverse-string`, `say`, `variable-length-quantity`, and `word-count`. `say` will need some retooling since each step is tested as a separate property when it should be a single property being tested throughout. That'll break about 40 completions so that's not too bad especially given we're making the exercise more canonical. 