### PR TITLE
Add canonical tests to `hamming`

### DIFF
--- a/exercises/practice/hamming/hamming-test.rkt
+++ b/exercises/practice/hamming/hamming-test.rkt
@@ -7,30 +7,42 @@
 
   (define suite
     (test-suite
-     "point mutations tests"
+     "hamming tests"
 
-     (test-eqv? "no difference between empty strands"
-                (hamming-distance "" "")
-                0)
+     (test-equal? "empty strands"
+                  (hamming-distance "" "")
+                  0)
+    
+     (test-equal? "single letter identical strands"
+                  (hamming-distance "A" "A")
+                  0)
 
-     (test-eqv? "no difference between identical strands"
-                (hamming-distance "GATTACA" "GATTACA")
-                0)
+     (test-equal? "single letter different strands"
+                  (hamming-distance "G" "T")
+                  1)
+              
+     (test-equal? "long identical strands"
+                  (hamming-distance "GGACTGAAATCTG" "GGACTGAAATCTG")
+                  0)
 
-     (test-eqv? "complete hamming distance in small strand"
-                (hamming-distance "ACT" "GGA")
-                3)
+     (test-equal? "long different strands"
+                  (hamming-distance "GGACGGATTCTG" "AGGACGGATTCT")
+                  9)
 
-     (test-eqv? "small hamming distance in middle somewhere"
-                (hamming-distance "GGACG" "GGTCG")
-                1)
-
-     (test-eqv? "larger difference"
-                (hamming-distance "ACCAGGG" "ACTATGG")
-                2)
-
-     (test-exn "String length mismatch." exn:fail?
+     (test-exn "disallow first strand longer" exn:fail?
                (lambda ()
-                 (hamming-distance "AGACAACAGCCAGCCGCCGGATT" "AGGCAA")))))
+                 (hamming-distance "AATG" "AAA")))
+      
+     (test-exn "disallow second strand longer" exn:fail?
+               (lambda ()
+                 (hamming-distance "ATA" "AGTG")))
+
+     (test-exn "disallow left empty strand" exn:fail?
+               (lambda ()
+                 (hamming-distance "" "G")))
+
+     (test-exn "disallow right empty strand" exn:fail?
+               (lambda ()
+                 (hamming-distance "G" "")))))
 
   (run-tests suite))


### PR DESCRIPTION
Closes #217 by syncing canonical tests that include the scenario proposed there.