### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams can be returned in any order.

--- a/exercises/practice/atbash-cipher/.docs/instructions.append.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Note
+# Instructions append
+
+## Note
 
 The tests for this problem assume that numbers are passed through without being encrypted/decrypted.

--- a/exercises/practice/binary-search/.docs/instructions.append.md
+++ b/exercises/practice/binary-search/.docs/instructions.append.md
@@ -1,6 +1,9 @@
 # Instructions append
 
-In Racket, this exercise uses sorted [vectors] rather than lists because vectors support constant-time access of its elements. Like several other Lisp tracks, when an item isn't present in the vector, the expectation is that the [Boolean literal `#f`][booleans] will be returned rather than raising an exception. 
+## Implementation
+
+In Racket, this exercise uses sorted [vectors] rather than lists because vectors support constant-time access of its elements.
+Like several other Lisp tracks, when an item isn't present in the vector, the expectation is that the [Boolean literal `#f`][booleans] will be returned rather than raising an exception. 
 
 [vectors]: https://docs.racket-lang.org/guide/vectors.html
 [booleans]: https://docs.racket-lang.org/reference/booleans.html

--- a/exercises/practice/perfect-numbers/.docs/instructions.append.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.append.md
@@ -1,5 +1,5 @@
-# Implementation
+# Instructions append
 
-Implement a procedure named `classify` that takes a number as argument and returns either `'perfect`,
-`'abundant`, or `'deficient`.
+## Implementation
 
+Implement a procedure named `classify` that takes a number as argument and returns either `'perfect`, `'abundant`, or `'deficient`.

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Note
+  # Instructions append
+
+## Note
   
 For this problem, you will need to write the test.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.