### PR TITLE
Add version 9.2 to the CI test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - racket-version: '8.17'
-            racket-variant: 'BC'
-          - racket-version: '8.17'
+          - racket-version: '9.0'
             racket-variant: 'CS'
           - racket-version: '9.2'
             racket-variant: 'CS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ jobs:
             racket-variant: 'BC'
           - racket-version: '8.17'
             racket-variant: 'CS'
-          - racket-version: '8.18'
-            racket-variant: 'CS'
-          - racket-version: '9.0'
-            racket-variant: 'CS'
           - racket-version: '9.2'
             racket-variant: 'CS'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
             racket-variant: 'CS'
           - racket-version: '9.0'
             racket-variant: 'CS'
+          - racket-version: '9.2'
+            racket-variant: 'CS'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10


### PR DESCRIPTION
This matches https://github.com/exercism/racket-test-runner/pull/95
